### PR TITLE
SSR experiments

### DIFF
--- a/examples/svelte-ssr.js
+++ b/examples/svelte-ssr.js
@@ -1,0 +1,28 @@
+// Support for ESM
+require = require('esm')(module);
+
+// Svelte SSR require register
+require('svelte/ssr/register');
+
+// Get app
+const App = require('./svelte-ssr/App.html');
+
+// Render
+let { html, css, head } = App.render({});
+
+// Output
+console.log(`<!doctype html>
+<html lang="en">
+	<head>
+    ${head}
+
+		<style>
+			${css ? css.code : ''}
+		</style>
+  </head>
+
+	<body>
+		${html}
+	</body>
+</html>
+`);

--- a/examples/svelte-ssr.output.html
+++ b/examples/svelte-ssr.output.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+	<head>
+    
+
+		<style>
+			.layercake-chart-container,.layercake-chart-container *{box-sizing:border-box}.svelte-ref-chartContainer.svelte-1f8skbk{width:100%;height:100%}
+.svelte-ref-svgLayout.svelte-18jpo51{position:absolute;top:0;left:0}
+.tick.svelte-1uurhdk{font-size:0.725em;font-weight:200}line.svelte-1uurhdk,.tick.svelte-1uurhdk line.svelte-1uurhdk{stroke:#aaa;stroke-dasharray:2}.tick.svelte-1uurhdk text.svelte-1uurhdk{fill:#666}.baseline.svelte-1uurhdk{stroke-dasharray:0}
+.tick.svelte-3ujw68{font-size:0.725em;font-weight:200}.tick.svelte-3ujw68 line.svelte-3ujw68{stroke:#aaa;stroke-dasharray:2}.tick.svelte-3ujw68 text.svelte-3ujw68{fill:#666;text-anchor:start}.tick.tick-0.svelte-3ujw68 line.svelte-3ujw68{stroke-dasharray:0}
+.path-line.svelte-1m6pyvz{fill:none;stroke-linejoin:round;stroke-linecap:round;stroke-width:2}
+		</style>
+  </head>
+
+	<body>
+		
+<div class="chart-continer" style="box-sizing: border-box;">
+	<div class="layercake-chart-container svelte-1f8skbk svelte-ref-chartContainer" clientWidth=500 clientHeight=400>
+	<svg data-layout-index="0" data-layout="Svg" width="500" height="400" style="" class="svelte-18jpo51 svelte-ref-svgLayout">
+	
+	<g transform="translate(0, 0)">
+		<g>
+				<g class="axis x-axis">
+	<g class="tick tick-1 svelte-1uurhdk" transform="translate(0,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1</text>
+		</g><g class="tick tick-1.2 svelte-1uurhdk" transform="translate(33.33333333333333,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1.2</text>
+		</g><g class="tick tick-1.4 svelte-1uurhdk" transform="translate(66.66666666666666,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1.4</text>
+		</g><g class="tick tick-1.6 svelte-1uurhdk" transform="translate(100.00000000000001,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1.6</text>
+		</g><g class="tick tick-1.8 svelte-1uurhdk" transform="translate(133.33333333333334,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1.8</text>
+		</g><g class="tick tick-2 svelte-1uurhdk" transform="translate(166.66666666666666,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2</text>
+		</g><g class="tick tick-2.2 svelte-1uurhdk" transform="translate(200.00000000000003,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2.2</text>
+		</g><g class="tick tick-2.4 svelte-1uurhdk" transform="translate(233.33333333333331,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2.4</text>
+		</g><g class="tick tick-2.6 svelte-1uurhdk" transform="translate(266.6666666666667,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2.6</text>
+		</g><g class="tick tick-2.8 svelte-1uurhdk" transform="translate(300,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2.8</text>
+		</g><g class="tick tick-3 svelte-1uurhdk" transform="translate(333.3333333333333,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3</text>
+		</g><g class="tick tick-3.2 svelte-1uurhdk" transform="translate(366.6666666666667,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3.2</text>
+		</g><g class="tick tick-3.4 svelte-1uurhdk" transform="translate(399.99999999999994,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3.4</text>
+		</g><g class="tick tick-3.6 svelte-1uurhdk" transform="translate(433.33333333333337,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3.6</text>
+		</g><g class="tick tick-3.8 svelte-1uurhdk" transform="translate(466.66666666666663,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3.8</text>
+		</g><g class="tick tick-4 svelte-1uurhdk" transform="translate(500,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">4</text>
+		</g>
+	
+</g>
+			</g><g>
+				<g class="axis y-axis" transform="translate(-0, 0)">
+	<g class="tick tick-7 svelte-3ujw68" transform="translate(0, 400)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">7</text>
+		</g><g class="tick tick-8 svelte-3ujw68" transform="translate(0, 300)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">8</text>
+		</g><g class="tick tick-9 svelte-3ujw68" transform="translate(0, 200)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">9</text>
+		</g><g class="tick tick-10 svelte-3ujw68" transform="translate(0, 100)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">10</text>
+		</g><g class="tick tick-11 svelte-3ujw68" transform="translate(0, 0)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">11</text>
+		</g>
+</g>
+			</g><g>
+				<path class="path-line svelte-1m6pyvz" d="M0,100L166.66666666666666,300L333.3333333333333,400L500,0" style="stroke: #ab00d6;"></path>
+			</g>
+	</g>
+</svg>
+</div>
+</div>
+	</body>
+</html>
+

--- a/examples/svelte-ssr.ssr.html
+++ b/examples/svelte-ssr.ssr.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+	<head>
+    
+
+		<style>
+			.layercake-chart-container,.layercake-chart-container *{box-sizing:border-box}.svelte-ref-chartContainer.svelte-1f8skbk{width:100%;height:100%}
+.svelte-ref-svgLayout.svelte-18jpo51{position:absolute;top:0;left:0}
+.tick.svelte-1uurhdk{font-size:0.725em;font-weight:200}line.svelte-1uurhdk,.tick.svelte-1uurhdk line.svelte-1uurhdk{stroke:#aaa;stroke-dasharray:2}.tick.svelte-1uurhdk text.svelte-1uurhdk{fill:#666}.baseline.svelte-1uurhdk{stroke-dasharray:0}
+.tick.svelte-3ujw68{font-size:0.725em;font-weight:200}.tick.svelte-3ujw68 line.svelte-3ujw68{stroke:#aaa;stroke-dasharray:2}.tick.svelte-3ujw68 text.svelte-3ujw68{fill:#666;text-anchor:start}.tick.tick-0.svelte-3ujw68 line.svelte-3ujw68{stroke-dasharray:0}
+.path-line.svelte-1m6pyvz{fill:none;stroke-linejoin:round;stroke-linecap:round;stroke-width:2}
+		</style>
+  </head>
+
+	<body>
+		
+<div class="chart-continer" style="box-sizing: border-box;">
+	<div class="layercake-chart-container svelte-1f8skbk svelte-ref-chartContainer" clientWidth=500 clientHeight=400>
+	<svg data-layout-index="0" data-layout="Svg" width="500" height="400" style="" class="svelte-18jpo51 svelte-ref-svgLayout">
+	
+	<g transform="translate(0, 0)">
+		<g>
+				<g class="axis x-axis">
+	<g class="tick tick-1 svelte-1uurhdk" transform="translate(0,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1</text>
+		</g><g class="tick tick-1.2 svelte-1uurhdk" transform="translate(33.33333333333333,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1.2</text>
+		</g><g class="tick tick-1.4 svelte-1uurhdk" transform="translate(66.66666666666666,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1.4</text>
+		</g><g class="tick tick-1.6 svelte-1uurhdk" transform="translate(100.00000000000001,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1.6</text>
+		</g><g class="tick tick-1.8 svelte-1uurhdk" transform="translate(133.33333333333334,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">1.8</text>
+		</g><g class="tick tick-2 svelte-1uurhdk" transform="translate(166.66666666666666,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2</text>
+		</g><g class="tick tick-2.2 svelte-1uurhdk" transform="translate(200.00000000000003,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2.2</text>
+		</g><g class="tick tick-2.4 svelte-1uurhdk" transform="translate(233.33333333333331,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2.4</text>
+		</g><g class="tick tick-2.6 svelte-1uurhdk" transform="translate(266.6666666666667,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2.6</text>
+		</g><g class="tick tick-2.8 svelte-1uurhdk" transform="translate(300,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">2.8</text>
+		</g><g class="tick tick-3 svelte-1uurhdk" transform="translate(333.3333333333333,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3</text>
+		</g><g class="tick tick-3.2 svelte-1uurhdk" transform="translate(366.6666666666667,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3.2</text>
+		</g><g class="tick tick-3.4 svelte-1uurhdk" transform="translate(399.99999999999994,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3.4</text>
+		</g><g class="tick tick-3.6 svelte-1uurhdk" transform="translate(433.33333333333337,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3.6</text>
+		</g><g class="tick tick-3.8 svelte-1uurhdk" transform="translate(466.66666666666663,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">3.8</text>
+		</g><g class="tick tick-4 svelte-1uurhdk" transform="translate(500,400)">
+			<line y1="-400" y2="0" x1="0" x2="0" class="svelte-1uurhdk"></line>
+			<text y="16" text-anchor="middle" class="svelte-1uurhdk">4</text>
+		</g>
+	
+</g>
+			</g><g>
+				<g class="axis y-axis" transform="translate(-0, 0)">
+	<g class="tick tick-7 svelte-3ujw68" transform="translate(0, 400)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">7</text>
+		</g><g class="tick tick-8 svelte-3ujw68" transform="translate(0, 300)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">8</text>
+		</g><g class="tick tick-9 svelte-3ujw68" transform="translate(0, 200)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">9</text>
+		</g><g class="tick tick-10 svelte-3ujw68" transform="translate(0, 100)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">10</text>
+		</g><g class="tick tick-11 svelte-3ujw68" transform="translate(0, 0)">
+			<line x2="100%" class="svelte-3ujw68"></line>
+			<text y="-4" class="svelte-3ujw68">11</text>
+		</g>
+</g>
+			</g><g>
+				<path class="path-line svelte-1m6pyvz" d="M0,100L166.66666666666666,300L333.3333333333333,400L500,0" style="stroke: #ab00d6;"></path>
+			</g>
+	</g>
+</svg>
+</div>
+</div>
+	</body>
+</html>
+

--- a/examples/svelte-ssr/App.html
+++ b/examples/svelte-ssr/App.html
@@ -7,6 +7,7 @@
 	import LayerCake from "../../src/layercake.js";
 	import LayerCakeContainer from "../../src/LayerCakeContainer.html";
 	import AxisX from "./AxisX.html";
+	import AxisY from "./AxisY.html";
 	import Line from "./Line.html";
 
 	// Create layer cake store
@@ -25,9 +26,8 @@
 	  ssr: true
 	}).svgLayers([
 	  { component: AxisX, opts: {} },
-	  // { component: AxisY, opts: {} },
+	  { component: AxisY, opts: {} },
 	  { component: Line, opts: {} }
-	  // { component: Area, opts: {} }
 	]);
 
 	export default {

--- a/examples/svelte-ssr/App.html
+++ b/examples/svelte-ssr/App.html
@@ -1,0 +1,42 @@
+<!-- Manually set box-sizing -->
+<div class="chart-continer" ref:chart style="box-sizing: border-box;">
+	<LayerCakeContainer />
+</div>
+
+<script>
+	import LayerCake from "../../src/layercake.js";
+	import LayerCakeContainer from "../../src/LayerCakeContainer.html";
+	import AxisX from "./AxisX.html";
+	import Line from "./Line.html";
+
+	// Create layer cake store
+	const cakeData = [
+	  { cake: 1, score: 10 },
+	  { cake: 2, score: 8 },
+	  { cake: 3, score: 7 },
+	  { cake: 4, score: 11 }
+	];
+	const exampleCake = new LayerCake({
+	  data: cakeData,
+	  x: "cake",
+	  y: "score",
+	  width: 500,
+	  height: 400,
+	  ssr: true
+	}).svgLayers([
+	  { component: AxisX, opts: {} },
+	  // { component: AxisY, opts: {} },
+	  { component: Line, opts: {} }
+	  // { component: Area, opts: {} }
+	]);
+
+	export default {
+	  components: {
+	    LayerCakeContainer
+	  },
+
+	  store: () => {
+	    return exampleCake;
+	  }
+	};
+</script>

--- a/examples/svelte-ssr/App.html
+++ b/examples/svelte-ssr/App.html
@@ -10,6 +10,9 @@
 	import AxisY from "./AxisY.html";
 	import Line from "./Line.html";
 
+	// Is Browser
+	const isBrowser = typeof window !== 'undefined';
+
 	// Create layer cake store
 	const cakeData = [
 	  { cake: 1, score: 10 },
@@ -18,12 +21,13 @@
 	  { cake: 4, score: 11 }
 	];
 	const exampleCake = new LayerCake({
-	  data: cakeData,
+		data: cakeData,
+		padding: { top: 10, left: 10, right: 10, bottom: 10 },
 	  x: "cake",
 	  y: "score",
 	  width: 500,
 	  height: 400,
-	  ssr: true
+	  ssr: !isBrowser
 	}).svgLayers([
 	  { component: AxisX, opts: {} },
 	  { component: AxisY, opts: {} },

--- a/examples/svelte-ssr/AxisX.html
+++ b/examples/svelte-ssr/AxisX.html
@@ -1,0 +1,55 @@
+<g class='axis x-axis'>
+	{#each ticks as tick, i}
+		<g class='tick tick-{ tick }' transform='translate({$xScale(tick)},{$yScale.range()[0]})'>
+			{#if opts.gridlines !== false}
+				<line y1='{$height * -1}' y2='0' x1='0' x2='0'></line>
+			{/if}
+			<text y='16' text-anchor='{textAnchor(i)}'>{opts.formatTick ? opts.formatTick(tick) : tick}</text>
+		</g>
+	{/each}
+	{#if opts.baseline === true}
+		<line class="baseline" y1='{$height + 0.5}' y2='{$height + 0.5}' x1='0' x2='{$width}'></line>
+	{/if}
+</g>
+
+<style>
+	.tick {
+	  font-size: 0.725em;
+	  font-weight: 200;
+	}
+	line,
+	.tick line {
+	  stroke: #aaa;
+	  stroke-dasharray: 2;
+	}
+	.tick text {
+	  fill: #666;
+	}
+	.baseline {
+	  stroke-dasharray: 0;
+	}
+</style>
+
+<script>
+	export default {
+	  namespace: "svg",
+	  computed: {
+	    ticks: ({ $xScale, opts }) => {
+	      return opts.ticks || $xScale.ticks(opts.tickNumber);
+	    },
+	    textAnchor: ({ ticks, opts }) => {
+	      return function(i) {
+	        if (opts.snapTicks === true) {
+	          if (i === 0) {
+	            return "start";
+	          }
+	          if (i === ticks.length - 1) {
+	            return "end";
+	          }
+	        }
+	        return "middle";
+	      };
+	    }
+	  }
+	};
+</script>

--- a/examples/svelte-ssr/AxisY.html
+++ b/examples/svelte-ssr/AxisY.html
@@ -1,0 +1,34 @@
+<g class='axis y-axis' transform='translate(-{$padding.left}, 0)'>
+	{#each $yScale.ticks(opts.ticks || opts.tickNumber || 5) as tick, i}
+		<g class='tick tick-{tick}' transform='translate(0, {$yScale(tick)})'>
+			{#if opts.gridlines !== false}
+				<line x2='100%'></line>
+			{/if}
+			<text y='-4'>{opts.formatTick ? opts.formatTick(tick) : tick}</text>
+		</g>
+	{/each}
+</g>
+
+<style>
+	.tick {
+	  font-size: 0.725em;
+	  font-weight: 200;
+	}
+	.tick line {
+	  stroke: #aaa;
+	  stroke-dasharray: 2;
+	}
+	.tick text {
+	  fill: #666;
+	  text-anchor: start;
+	}
+	.tick.tick-0 line {
+	  stroke-dasharray: 0;
+	}
+</style>
+
+<script>
+	export default {
+	  namespace: "svg"
+	};
+</script>

--- a/examples/svelte-ssr/Line.html
+++ b/examples/svelte-ssr/Line.html
@@ -1,0 +1,27 @@
+<path class='path-line' d='{path}' style="stroke: {opts.stroke || '#ab00d6'};"></path>
+<style>
+	.path-line {
+	  fill: none;
+	  stroke-linejoin: round;
+	  stroke-linecap: round;
+	  stroke-width: 2;
+	}
+</style>
+
+<script>
+	export default {
+	  namespace: "svg",
+	  computed: {
+	    path: ({ $data, $xGet, $yGet }) => {
+	      return (
+	        "M" +
+	        $data
+	          .map((d, i) => {
+	            return $xGet(d) + "," + $yGet(d);
+	          })
+	          .join("L")
+	      );
+	    }
+	  }
+	};
+</script>

--- a/src/layercake.js
+++ b/src/layercake.js
@@ -29,17 +29,20 @@ export { calcExtents };
 export default class LayerCakeStore extends Store {
 	constructor (config) {
 		/* --------------------------------------------
-		 * Set border box so padding works correctly
+		 * Set border box so padding works correctly. In SSR mode,
+		 * there's no need to set this.
 		 */
-		config.target.style['box-sizing'] = 'border-box';
+		if (!config.ssr) {
+			config.target.style['box-sizing'] = 'border-box';
+		}
 
 		/* --------------------------------------------
 		 * Main values
 		 */
 		const coreValues = {
 			data: config.data,
-			containerWidth: config.target.clientWidth,
-			containerHeight: config.target.clientHeight,
+			containerWidth: config.width || config.target.clientWidth,
+			containerHeight: config.height || config.target.clientHeight,
 			layouts: [],
 			target: config.target,
 			custom: config.custom || {}
@@ -121,10 +124,16 @@ export default class LayerCakeStore extends Store {
 	}
 
 	computeValues (settings, originalSettings) {
-		this.compute('padding', ['target', 'containerWidth', 'containerHeight'], target => {
+		this.compute('padding', ['target', 'containerWidth', 'containerHeight', 'ssr'], (target, containerWidth, containerHeight, ssr) => {
 			const defaultPadding = {top: 0, right: 0, bottom: 0, left: 0};
 			let hasPadding = false;
 			const padding = {};
+
+			if (ssr) {
+				// TODO: Can padding be defined in config if it's a computed
+				// value?
+				return defaultPadding;
+			}
 
 			const styles = window.getComputedStyle(target);
 			Object.keys(defaultPadding).forEach(p => {


### PR DESCRIPTION
Here is an experiment with SSR.  This pull request is not actually meant to be merged, as it may not be the best approach.

Overall, there are a couple things that hold LayerCake back from SSR:

* DOM API parts.  Particularly, getting the width and height and padding from the element.
* Rendering, specifically `oncreate`, doesn't work as it doesn't get called in SSR.

This approach uses a `ssr` option in the config.  This could maybe handled automatically by checking for `window` or `document`.  The changes to the library are simply avoiding the DOM API.

To get it then to render out HTML, instead of calling `render`, this approach uses the `LayerCakeContainer.html` directly in the Svelte template.

There's an example included, where `examples/svelte-ssr.html/App.html` is the main template and what we run through Svelte's compiling.  The `example/svelte-ssr.js` is the small script to do the rendering.  So, you can do something like `node examples/svelte-ssr.js > examples/svelte-ssr.output.html` to create an HTML file that can be loaded in the browser.