### PR TITLE
Add `"type": "module"` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "test": "mocha --require esm test/*.js"
   },
   "license": "MIT",
-  "main": "src/index.js",
+  "type": "module",
+	"main": "src/index.js",
   "module": "src/index.js",
   "devDependencies": {
     "eslint": "^6.1.0",


### PR DESCRIPTION
The latest version of Vite will log a warning about this library being incorrectly packaged because the entry point is ESM without specifying either `"type": "module"` or having an `.mjs` extension. This will fix the issue