### PR TITLE
Draft: add attribute control for components + docs

### DIFF
--- a/src/content/guide/05-layout-component-props.md
+++ b/src/content/guide/05-layout-component-props.md
@@ -6,6 +6,7 @@ All layout components accept the following props:
 
 * [zIndex](guide#zindex-1) `Number|String`
 * [pointerEvents](guide#pointerevents-1) `Boolean`
+* [attrs](guide#attrs-1)
 
 The Svg and ScaledSvg layout components also accept:
 
@@ -83,6 +84,18 @@ Useful for tooltip layers that need to be display above chart elements but not c
     pointerEvents={false}
   >
   </Html>
+</LayerCake>
+```
+
+### attrs `Object|null`
+
+This allows you to add attributes onto the main container of any of the layout components
+(i.e. the `<svg>` tag for `Svg` and `ScaledSvg`; the `<canvas>` tag for `Webgl` and `Canvas`; and the `<div>` tag for `Html`). 
+
+```svelte
+<LayerCake ...>
+  <Svg attrs={{role: "img", title: "A graphic description"}}>
+  </Svg>
 </LayerCake>
 ```
 

--- a/src/lib/layouts/Canvas.svelte
+++ b/src/lib/layouts/Canvas.svelte
@@ -19,6 +19,19 @@
 	/** @type {Boolean} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
 	export let pointerEvents = undefined;
 
+	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the `<canvas>` tag*/
+		export let attrs = null;
+
+	$: if (element && attrs) {
+		const attrList = Object.entries(attrs);
+		for (let i = 0; i < attrList.length; i++) {
+			const [attr, property] = attrList[i];
+			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
+				element.setAttribute(attr, property);
+			}
+		}
+	}
+
 	const { width, height, padding } = getContext('LayerCake');
 
 	const cntxt = {

--- a/src/lib/layouts/Canvas.svelte
+++ b/src/lib/layouts/Canvas.svelte
@@ -5,7 +5,9 @@
 <script>
 	import { getContext, onMount, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
+
 	import scaleCanvas from '../lib/scaleCanvas.js';
+	import setElementAttributes from '../utils/setElementAttributes.js';
 
 	/** @type {HTMLCanvasElement} [element] The `<canvas>` tag. Useful for bindings. */
 	export let element = undefined;
@@ -19,18 +21,11 @@
 	/** @type {Boolean} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
 	export let pointerEvents = undefined;
 
-	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the `<canvas>` tag*/
+	/** @type {Object} [attrs] An object of key-value pairs that sets additional attribute values onto the `<canvas>` tag for each key */
 		export let attrs = null;
 
-	$: if (element && attrs) {
-		const attrKeys = Object.keys(attrs);
-		for (let i = 0; i < attrKeys.length; i++) {
-			const attr = attrKeys[i];
-			const property = attrs[attr];
-			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
-				element.setAttribute(attr, property);
-			}
-		}
+	$: if (element && attrs ) {
+		setElementAttributes(element, attrs);
 	}
 
 	const { width, height, padding } = getContext('LayerCake');

--- a/src/lib/layouts/Canvas.svelte
+++ b/src/lib/layouts/Canvas.svelte
@@ -23,9 +23,10 @@
 		export let attrs = null;
 
 	$: if (element && attrs) {
-		const attrList = Object.entries(attrs);
-		for (let i = 0; i < attrList.length; i++) {
-			const [attr, property] = attrList[i];
+		const attrKeys = Object.keys(attrs);
+		for (let i = 0; i < attrKeys.length; i++) {
+			const attr = attrKeys[i];
+			const property = attrs[attr];
 			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
 				element.setAttribute(attr, property);
 			}

--- a/src/lib/layouts/Html.svelte
+++ b/src/lib/layouts/Html.svelte
@@ -5,6 +5,8 @@
 <script>
 	import { getContext } from 'svelte';
 
+	import setElementAttributes from '../utils/setElementAttributes.js';
+
 	/** @type {Element} [element] The layer's outermost `<div>` tag. Useful for bindings. */
 	export let element = undefined;
 
@@ -14,18 +16,11 @@
 	/** @type {Boolean} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
 	export let pointerEvents = undefined;
 
-	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the outer `<div>` tag*/
+	/** @type {Object} [attrs] An object of key-value pairs that sets additional attribute values onto the outer `<div>` tag for each key */
 		export let attrs = null;
 
 	$: if (element && attrs) {
-		const attrKeys = Object.keys(attrs);
-		for (let i = 0; i < attrKeys.length; i++) {
-			const attr = attrKeys[i];
-			const property = attrs[attr];
-			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
-				element.setAttribute(attr, property);
-			}
-		}
+		setElementAttributes(element, attrs);
 	}
 
 	const { padding } = getContext('LayerCake');

--- a/src/lib/layouts/Html.svelte
+++ b/src/lib/layouts/Html.svelte
@@ -18,9 +18,10 @@
 		export let attrs = null;
 
 	$: if (element && attrs) {
-		const attrList = Object.entries(attrs);
-		for (let i = 0; i < attrList.length; i++) {
-			const [attr, property] = attrList[i];
+		const attrKeys = Object.keys(attrs);
+		for (let i = 0; i < attrKeys.length; i++) {
+			const attr = attrKeys[i];
+			const property = attrs[attr];
 			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
 				element.setAttribute(attr, property);
 			}

--- a/src/lib/layouts/Html.svelte
+++ b/src/lib/layouts/Html.svelte
@@ -14,6 +14,19 @@
 	/** @type {Boolean} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
 	export let pointerEvents = undefined;
 
+	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the outer `<div>` tag*/
+		export let attrs = null;
+
+	$: if (element && attrs) {
+		const attrList = Object.entries(attrs);
+		for (let i = 0; i < attrList.length; i++) {
+			const [attr, property] = attrList[i];
+			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
+				element.setAttribute(attr, property);
+			}
+		}
+	}
+
 	const { padding } = getContext('LayerCake');
 </script>
 

--- a/src/lib/layouts/ScaledSvg.svelte
+++ b/src/lib/layouts/ScaledSvg.svelte
@@ -5,6 +5,8 @@
 <script>
 	import { getContext } from 'svelte';
 
+	import setElementAttributes from '../utils/setElementAttributes.js';
+
 	/** @type {Element} [element] The layer's `<svg>` tag. Useful for bindings. */
 	export let element = undefined;
 
@@ -20,18 +22,11 @@
 	/** @type {String} [viewBox=`0 0 100 ${100 / fixedAspectRatio}`] A string passed to the viewBox property on the `<svg>` tag. */
 	export let viewBox = `0 0 100 ${100 / fixedAspectRatio}`;
 
-	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the `<svg>` tag*/
+	/** @type {Object} [attrs] An object of key-value pairs that sets additional attribute values onto the `<svg>` tag for each key */
 		export let attrs = null;
 
 	$: if (element && attrs) {
-		const attrKeys = Object.keys(attrs);
-		for (let i = 0; i < attrKeys.length; i++) {
-			const attr = attrKeys[i];
-			const property = attrs[attr];
-			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
-				element.setAttribute(attr, property);
-			}
-		}
+		setElementAttributes(element, attrs);
 	}
 
 	const { padding } = getContext('LayerCake');

--- a/src/lib/layouts/ScaledSvg.svelte
+++ b/src/lib/layouts/ScaledSvg.svelte
@@ -20,6 +20,19 @@
 	/** @type {String} [viewBox=`0 0 100 ${100 / fixedAspectRatio}`] A string passed to the viewBox property on the `<svg>` tag. */
 	export let viewBox = `0 0 100 ${100 / fixedAspectRatio}`;
 
+	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the `<svg>` tag*/
+		export let attrs = null;
+
+	$: if (element && attrs) {
+		const attrList = Object.entries(attrs);
+		for (let i = 0; i < attrList.length; i++) {
+			const [attr, property] = attrList[i];
+			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
+				element.setAttribute(attr, property);
+			}
+		}
+	}
+
 	const { padding } = getContext('LayerCake');
 </script>
 

--- a/src/lib/layouts/ScaledSvg.svelte
+++ b/src/lib/layouts/ScaledSvg.svelte
@@ -24,9 +24,10 @@
 		export let attrs = null;
 
 	$: if (element && attrs) {
-		const attrList = Object.entries(attrs);
-		for (let i = 0; i < attrList.length; i++) {
-			const [attr, property] = attrList[i];
+		const attrKeys = Object.keys(attrs);
+		for (let i = 0; i < attrKeys.length; i++) {
+			const attr = attrKeys[i];
+			const property = attrs[attr];
 			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
 				element.setAttribute(attr, property);
 			}

--- a/src/lib/layouts/Svg.svelte
+++ b/src/lib/layouts/Svg.svelte
@@ -5,6 +5,8 @@
 <script>
 	import { getContext } from 'svelte';
 
+	import setElementAttributes from '../utils/setElementAttributes.js';
+
 	/** @type {Element} [element] The layer's `<svg>` tag. Useful for bindings. */
 	export let element = undefined;
 
@@ -20,18 +22,11 @@
 	/** @type {String} [viewBox] A string passed to the viewBox property on the `<svg>` tag. */
 	export let viewBox = undefined;
 
-	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the `<svg>` tag*/
+	/** @type {Object} [attrs] An object of key-value pairs that sets additional attribute values onto the `<svg>` tag for each key */
 		export let attrs = null;
 
 	$: if (element && attrs) {
-		const attrKeys = Object.keys(attrs);
-		for (let i = 0; i < attrKeys.length; i++) {
-			const attr = attrKeys[i];
-			const property = attrs[attr];
-			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
-				element.setAttribute(attr, property);
-			}
-		}
+		setElementAttributes(element, attrs);
 	}
 
 	const { containerWidth, containerHeight, padding } = getContext('LayerCake');

--- a/src/lib/layouts/Svg.svelte
+++ b/src/lib/layouts/Svg.svelte
@@ -24,9 +24,10 @@
 		export let attrs = null;
 
 	$: if (element && attrs) {
-		const attrList = Object.entries(attrs);
-		for (let i = 0; i < attrList.length; i++) {
-			const [attr, property] = attrList[i];
+		const attrKeys = Object.keys(attrs);
+		for (let i = 0; i < attrKeys.length; i++) {
+			const attr = attrKeys[i];
+			const property = attrs[attr];
 			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
 				element.setAttribute(attr, property);
 			}

--- a/src/lib/layouts/Svg.svelte
+++ b/src/lib/layouts/Svg.svelte
@@ -20,6 +20,19 @@
 	/** @type {String} [viewBox] A string passed to the viewBox property on the `<svg>` tag. */
 	export let viewBox = undefined;
 
+	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the `<svg>` tag*/
+		export let attrs = null;
+
+	$: if (element && attrs) {
+		const attrList = Object.entries(attrs);
+		for (let i = 0; i < attrList.length; i++) {
+			const [attr, property] = attrList[i];
+			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
+				element.setAttribute(attr, property);
+			}
+		}
+	}
+
 	const { containerWidth, containerHeight, padding } = getContext('LayerCake');
 </script>
 <svg

--- a/src/lib/layouts/Webgl.svelte
+++ b/src/lib/layouts/Webgl.svelte
@@ -21,6 +21,19 @@
 	/** @type {WebGLRenderingContext} [context] The `<canvas>`'s WebGL context. Useful for bindings. */
 	export let context = undefined;
 
+	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the `<canvas>` tag*/
+		export let attrs = null;
+
+	$: if (element && attrs) {
+		const attrList = Object.entries(attrs);
+		for (let i = 0; i < attrList.length; i++) {
+			const [attr, property] = attrList[i];
+			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
+				element.setAttribute(attr, property);
+			}
+		}
+	}
+
 	let testGl;
 
 	const { padding } = getContext('LayerCake');

--- a/src/lib/layouts/Webgl.svelte
+++ b/src/lib/layouts/Webgl.svelte
@@ -6,6 +6,8 @@
 	import { getContext, onMount, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
 
+	import setElementAttributes from '../utils/setElementAttributes.js';
+
 	/** @type {HTMLCanvasElement} [element] The `<canvas>` tag. Useful for bindings. */
 	export let element = undefined;
 
@@ -21,18 +23,11 @@
 	/** @type {WebGLRenderingContext} [context] The `<canvas>`'s WebGL context. Useful for bindings. */
 	export let context = undefined;
 
-	/** @type {Object|null} [attrs] An object that sets additional attribute values onto the `<canvas>` tag*/
+	/** @type {Object} [attrs] An object of key-value pairs that sets additional attribute values onto the `<canvas>` tag for each key*/
 		export let attrs = null;
 
 	$: if (element && attrs) {
-		const attrKeys = Object.keys(attrs);
-		for (let i = 0; i < attrKeys.length; i++) {
-			const attr = attrKeys[i];
-			const property = attrs[attr];
-			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
-				element.setAttribute(attr, property);
-			}
-		}
+		setElementAttributes(element, attrs);
 	}
 
 	let testGl;

--- a/src/lib/layouts/Webgl.svelte
+++ b/src/lib/layouts/Webgl.svelte
@@ -25,9 +25,10 @@
 		export let attrs = null;
 
 	$: if (element && attrs) {
-		const attrList = Object.entries(attrs);
-		for (let i = 0; i < attrList.length; i++) {
-			const [attr, property] = attrList[i];
+		const attrKeys = Object.keys(attrs);
+		for (let i = 0; i < attrKeys.length; i++) {
+			const attr = attrKeys[i];
+			const property = attrs[attr];
 			if (!element.hasAttribute(attr) || element.getAttribute(attr) !== property) {
 				element.setAttribute(attr, property);
 			}

--- a/src/lib/utils/setElementAttributes.js
+++ b/src/lib/utils/setElementAttributes.js
@@ -1,0 +1,15 @@
+/* --------------------------------------------
+ * Set attributes on an element
+ */
+export default function setElementAttributes(element, attrs) {
+	if (typeof attrs === 'object' && !Array.isArray(attrs) && attrs !== null) {
+		const attrKeys = Object.keys(attrs);
+		for (let i = 0; i < attrKeys.length; i++) {
+			const attr = attrKeys[i];
+			const property = attrs[attr];
+			if (element.getAttribute(attr) !== property) {
+				element.setAttribute(attr, property);
+			}
+		}
+	}
+}

--- a/src/lib/utils/setElementAttributes.js
+++ b/src/lib/utils/setElementAttributes.js
@@ -11,5 +11,7 @@ export default function setElementAttributes(element, attrs) {
 				element.setAttribute(attr, property);
 			}
 		}
+	} else {
+		console.warn('[LayerCake] `attrs` property must be an object. You passed in:', attrs);
 	}
 }


### PR DESCRIPTION
This adds attribute-level control to the `Svg`, `ScaledSvg`, `Canvas`, `Html`, and `Webgl` layout layers. Addresses #71 .