### PR TITLE
[docs] fix duplicate width properties

### DIFF
--- a/src/content/guide/00-introduction.md
+++ b/src/content/guide/00-introduction.md
@@ -274,7 +274,7 @@ Here's an example that doesn't set any properties on the `LayerCake` component:
 	*/
   .chart-container {
     width: 100%;
-    width: 300px;
+    height: 300px;
   }
 </style>
 


### PR DESCRIPTION
Noticed this incorrect CSS styling while looking at the prop-less LayerCake example

```svelte
.chart-container {
  width: 100%;
  width: 300px; // should be height: 300px;
}
```