### PR TITLE
Support passing `count` as argument to `xNice` prop (et al.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ===
 
+# 7.1.0
+
+Allow for all `nNice` props to take a number instead of just a boolean. [PR #101](https://github.com/mhkeller/layercake/pull/101) from [@techniq](https://github.com/techniq).
+
 # 7.0.0
 
 > 2022-07-10

--- a/src/content/guide/02-layercake-props.md
+++ b/src/content/guide/02-layercake-props.md
@@ -262,19 +262,19 @@ Same as [xPadding](/guide#xpadding) but for the z domain.
 
 Same as [xPadding](/guide#xpadding) but for the r domain.
 
-### xNice `Boolean=false`
+### xNice `Boolean=false|Number`
 
-Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the x domain. This is a separate option instead of being one you can apply to a passed in scale because D3's "nice" transformation only works on existing domains and does not use a state to be able to tell if your existing scale wants to be nice.
+Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the x domain. This is a separate option instead of being one you can apply to a passed in scale because D3's "nice" transformation only works on existing domains and does not use a state to be able to tell if your existing scale wants to be nice.  Can also pass `count` number as argument for greater control.
 
-### yNice `Boolean=false`
+### yNice `Boolean=false|Number`
 
 Same as [xNice](/guide#xnice) but for the y domain.
 
-### zNice `Boolean=false`
+### zNice `Boolean=false|Number`
 
 Same as [xNice](/guide#xnice) but for the z domain.
 
-### rNice `Boolean=false`
+### rNice `Boolean=false|Number`
 
 Same as [xNice](/guide#xnice) but for the r domain.
 

--- a/src/lib/LayerCake.svelte
+++ b/src/lib/LayerCake.svelte
@@ -64,11 +64,11 @@
 	export let zDomain = undefined;
 	/** @type {[min: ?Number, max: ?Number]|String[]|Number[]|Function} [rDomain] Set a min or max. For linear scales, if you want to inherit the value from the data's extent, set that value to `null`. This value can also be an array because sometimes your scales are [piecewise](https://github.com/d3/d3-scale#continuous_domain) or are a list of discrete values such as in [ordinal scales](https://github.com/d3/d3-scale#ordinal-scales), useful for color series. Set it to a function that receives the computed domain and lets you return a modified domain, useful for sorting values. */
 	export let rDomain = undefined;
-	/** @type {Boolean} [xNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the x domain. */
+	/** @type {Boolean|Number} [xNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the x domain. */
 	export let xNice = false;
-	/** @type {Boolean} [yNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the y domain. */
+	/** @type {Boolean|Number} [yNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the y domain. */
 	export let yNice = false;
-	/** @type {Boolean} [zNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the z domain. */
+	/** @type {Boolean|Number} [zNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the z domain. */
 	export let zNice = false;
 	/** @type {Boolean} [rNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the r domain. */
 	export let rNice = false;

--- a/src/lib/helpers/createScale.js
+++ b/src/lib/helpers/createScale.js
@@ -39,11 +39,7 @@ export default function createScale (s) {
 
 		if ($nice === true || typeof $nice === 'number') {
 			if (typeof scale.nice === 'function') {
-				if (typeof $nice === 'number') {
-					scale.nice($nice);
-				} else {
-					scale.nice();
-				}
+				scale.nice(typeof $nice === 'number' ? $nice : undefined);
 			} else {
 				console.error(`[Layer Cake] You set \`${s}Nice: true\` but the ${s}Scale does not have a \`.nice\` method. Ignoring...`);
 			}

--- a/src/lib/helpers/createScale.js
+++ b/src/lib/helpers/createScale.js
@@ -37,9 +37,13 @@ export default function createScale (s) {
 			scale.domain(padScale(scale, $padding));
 		}
 
-		if ($nice === true) {
+		if ($nice === true || typeof $nice === 'number') {
 			if (typeof scale.nice === 'function') {
-				scale.nice();
+				if (typeof $nice === 'number') {
+					scale.nice($nice);
+				} else {
+					scale.nice();
+				}
 			} else {
 				console.error(`[Layer Cake] You set \`${s}Nice: true\` but the ${s}Scale does not have a \`.nice\` method. Ignoring...`);
 			}

--- a/src/routes/_examples/Line.svelte
+++ b/src/routes/_examples/Line.svelte
@@ -35,6 +35,7 @@
 		padding={{ right: 10, bottom: 20, left: 25 }}
 		x={xKey}
 		y={yKey}
+		yNice={4}
 		yDomain={[0, null]}
 		data={data}
 	>

--- a/src/routes/_examples/Line.svelte
+++ b/src/routes/_examples/Line.svelte
@@ -32,7 +32,7 @@
 
 <div class="chart-container">
 	<LayerCake
-		padding={{ right: 10, bottom: 20, left: 25 }}
+		padding={{ top: 8, right: 10, bottom: 20, left: 25 }}
 		x={xKey}
 		y={yKey}
 		yNice={4}

--- a/src/routes/_examples_ssr/Line.svelte
+++ b/src/routes/_examples_ssr/Line.svelte
@@ -37,6 +37,7 @@
 		padding={{ right: 10, bottom: 20, left: 25 }}
 		x={xKey}
 		y={d => d[yKey]}
+		yNice={4}
 		yDomain={[0, null]}
 		data={data}
 	>

--- a/src/routes/_examples_ssr/Line.svelte
+++ b/src/routes/_examples_ssr/Line.svelte
@@ -34,7 +34,7 @@
 	<LayerCake
 		ssr={true}
 		percentRange={true}
-		padding={{ right: 10, bottom: 20, left: 25 }}
+		padding={{ top: 8, right: 10, bottom: 20, left: 25 }}
 		x={xKey}
 		y={d => d[yKey]}
 		yNice={4}


### PR DESCRIPTION
Resolves #99

Currently...

<img width="836" alt="image" src="https://user-images.githubusercontent.com/177476/193474056-8369a9b0-370a-4424-aa32-cb1b2e216792.png">


...after passing `yNice={4}` (which matches [AxisY](https://github.com/mhkeller/layercake/blob/main/src/_components/AxisY.svelte#L20) `ticks = 4` default)

<img width="836" alt="image" src="https://user-images.githubusercontent.com/177476/193474060-3a054fd4-a9a3-4887-b337-9448c986f3cc.png">
