### PR TITLE
Fix link to SSR MultiLine example

### DIFF
--- a/src/content/examples/MultiLine.md
+++ b/src/content/examples/MultiLine.md
@@ -62,4 +62,4 @@ A multiline example with a quadtree tooltip. This is an interesting example beca
      ...
    ```
 
-We're using Layer Cake's [groupLonger transform function](/guide#grouplonger) to do steps one and two. See the [server-side rendered example](/example-ssr/Multiline) for a regular JavaScript transform.
+We're using Layer Cake's [groupLonger transform function](/guide#grouplonger) to do steps one and two. See the [server-side rendered example](/example-ssr/MultiLine) for a regular JavaScript transform.


### PR DESCRIPTION
Just a tiny link fix to the MultiLine SSR example.

The link on 

https://layercake.graphics/example/MultiLine
to 

https://layercake.graphics/example-ssr/Multiline

doesn't work, needs to be

https://layercake.graphics/example-ssr/MultiLine