### PR TITLE
Fix comments for Line and Area component

### DIFF
--- a/src/_components/Area.svelte
+++ b/src/_components/Area.svelte
@@ -1,6 +1,6 @@
 <!--
 	@component
-	Generates an SVG area shape using the `area` function from [d3-shape](https://github.com/d3/d3-shape).
+	Generates an SVG area shape.
  -->
 <script>
 	import { getContext } from 'svelte';
@@ -16,6 +16,7 @@
 		})
 		.join('L');
 
+	/**	@type {String} **/
 	let area;
 
 	$: {

--- a/src/_components/Line.svelte
+++ b/src/_components/Line.svelte
@@ -1,6 +1,6 @@
 <!--
 	@component
-	Generates an SVG area shape using the `area` function from [d3-shape](https://github.com/d3/d3-shape).
+	Generates an SVG line shape.
  -->
 <script>
 	import { getContext } from 'svelte';


### PR DESCRIPTION
Maybe there is a better more detailed description possible, but the current one seems to be copy-n-paste from Area-D3 (d3-area is not used in these two here.).

Adds a type information as well to silence a warning.