### PR TITLE
Fix #193: clickable docs code samples on Svelte 5

### DIFF
--- a/src/routes/components/[slug]/+page.svelte
+++ b/src/routes/components/[slug]/+page.svelte
@@ -19,9 +19,9 @@
 	/** @type {import('./$types').PageData} */
 	export let data;
 	let {slug, content, active} = data;
-	$: if (slug !== data.slug) {
-		({slug, content, active} = data);
-	}
+	$: slug = data.slug;
+	$: content = data.content;
+	$: active = data.active;
 
 	function markdownToHtml(text) {
 		return md.render(text);

--- a/src/routes/components/[slug]/+page.svelte
+++ b/src/routes/components/[slug]/+page.svelte
@@ -19,7 +19,9 @@
 	/** @type {import('./$types').PageData} */
 	export let data;
 	let {slug, content, active} = data;
-	$: ({slug, content, active} = data);
+	$: if (slug !== data.slug) {
+		({slug, content, active} = data);
+	}
 
 	function markdownToHtml(text) {
 		return md.render(text);

--- a/src/routes/components/[slug]/+page.svelte
+++ b/src/routes/components/[slug]/+page.svelte
@@ -18,7 +18,6 @@
 
 	/** @type {import('./$types').PageData} */
 	export let data;
-	let {slug, content, active} = data;
 	$: slug = data.slug;
 	$: content = data.content;
 	$: active = data.active;

--- a/src/routes/example-ssr/[slug]/+page.svelte
+++ b/src/routes/example-ssr/[slug]/+page.svelte
@@ -19,9 +19,9 @@
 	/** @type {import('./$types').PageData} */
 	export let data;
 	let {slug, content, active} = data;
-	$: if (slug !== data.slug) {
-		({slug, content, active} = data);
-	}
+	$: slug = data.slug;
+	$: content = data.content;
+	$: active = data.active;
 
 	function markdownToHtml (text) {
 		return md.render(text);

--- a/src/routes/example-ssr/[slug]/+page.svelte
+++ b/src/routes/example-ssr/[slug]/+page.svelte
@@ -18,7 +18,6 @@
 
 	/** @type {import('./$types').PageData} */
 	export let data;
-	let {slug, content, active} = data;
 	$: slug = data.slug;
 	$: content = data.content;
 	$: active = data.active;

--- a/src/routes/example-ssr/[slug]/+page.svelte
+++ b/src/routes/example-ssr/[slug]/+page.svelte
@@ -16,9 +16,12 @@
 		linkify: true
 	});
 
-	export let data
-	let {slug, content, active} = data
-	$: ({slug, content, active} = data)
+	/** @type {import('./$types').PageData} */
+	export let data;
+	let {slug, content, active} = data;
+	$: if (slug !== data.slug) {
+		({slug, content, active} = data);
+	}
 
 	function markdownToHtml (text) {
 		return md.render(text);

--- a/src/routes/example/[slug]/+page.svelte
+++ b/src/routes/example/[slug]/+page.svelte
@@ -19,9 +19,9 @@
 	/** @type {import('./$types').PageData} */
 	export let data;
 	let {slug, content, active} = data;
-	$: if (slug !== data.slug) {
-		({slug, content, active} = data);
-	}
+	$: slug = data.slug;
+	$: content = data.content;
+	$: active = data.active;
 
 	function markdownToHtml (text) {
 		return md.render(text);

--- a/src/routes/example/[slug]/+page.svelte
+++ b/src/routes/example/[slug]/+page.svelte
@@ -18,7 +18,6 @@
 
 	/** @type {import('./$types').PageData} */
 	export let data;
-	let {slug, content, active} = data;
 	$: slug = data.slug;
 	$: content = data.content;
 	$: active = data.active;

--- a/src/routes/example/[slug]/+page.svelte
+++ b/src/routes/example/[slug]/+page.svelte
@@ -16,9 +16,12 @@
 	hljs.registerLanguage('svelte', hljsDefineSvelte);
 	hljsDefineSvelte(hljs);
 
-	export let data
-	let {slug, content, active} = data
-	$: ({slug, content, active} = data)
+	/** @type {import('./$types').PageData} */
+	export let data;
+	let {slug, content, active} = data;
+	$: if (slug !== data.slug) {
+		({slug, content, active} = data);
+	}
 
 	function markdownToHtml (text) {
 		return md.render(text);


### PR DESCRIPTION
This fixes #193. It looks like Svelte 5 slightly changes how reactivity works with `$:` on the data prop on a SvelteKit route.

~I added `if (slug !== data.slug)` so that the page content will still update on a navigation to a different frontend page. But this prevents the component from having `active` stuck to be the first code file on the page.~