### PR TITLE
Fix rendering of components pages

### DIFF
--- a/src/routes/components/[slug]/+page.svelte
+++ b/src/routes/components/[slug]/+page.svelte
@@ -18,6 +18,7 @@
 
 	/** @type {import('./$types').PageData} */
 	export let data;
+	let {slug, content, active} = data;
 	$: slug = data.slug;
 	$: content = data.content;
 	$: active = data.active;

--- a/src/routes/example-ssr/[slug]/+page.svelte
+++ b/src/routes/example-ssr/[slug]/+page.svelte
@@ -18,6 +18,7 @@
 
 	/** @type {import('./$types').PageData} */
 	export let data;
+	let {slug, content, active} = data;
 	$: slug = data.slug;
 	$: content = data.content;
 	$: active = data.active;

--- a/src/routes/example/[slug]/+page.svelte
+++ b/src/routes/example/[slug]/+page.svelte
@@ -18,6 +18,7 @@
 
 	/** @type {import('./$types').PageData} */
 	export let data;
+	let {slug, content, active} = data;
 	$: slug = data.slug;
 	$: content = data.content;
 	$: active = data.active;


### PR DESCRIPTION
Sorry about not testing the last change thoroughly in #194 — the removal of the `let` line broke the components pages.