### PR TITLE
Adds index to accessor functions

### DIFF
--- a/src/lib/helpers/createGetter.js
+++ b/src/lib/helpers/createGetter.js
@@ -1,6 +1,6 @@
 export default function createGetter ([$acc, $scale]) {
-	return d => {
-		const val = $acc(d);
+	return (d, i) => {
+		const val = $acc(d, i);
 		if (Array.isArray(val)) {
 			return val.map(v => $scale(v));
 		}

--- a/src/lib/lib/calcExtents.js
+++ b/src/lib/lib/calcExtents.js
@@ -44,7 +44,7 @@ export default function calcExtents (data, fields) {
 		min = null;
 		max = null;
 		for (j = 0; j < dl; j += 1) {
-			val = acc(data[j]);
+			val = acc(data[j], j);
 			if (Array.isArray(val)) {
 				const vl = val.length;
 				for (k = 0; k < vl; k += 1) {


### PR DESCRIPTION
Normally you're passing an array of objects but I've been thinking about alternate setups where maybe you want to keep your data as separate typed arrays for x and y. You'd have something like

```js
const xVector = new Uint32Array(data.map(d => d[xKey]));
const yVector = new Uint8Array(data.map(d => d[yKey]));
```

and then...

```html
...
x={(d, i) => xVector[i]}
y={(d, i) => yVector[i]}
data={someFakeDataHere}
```

This is kind of a weird setup but I could see it possibly being useful for high-performance cases. Either way, seems potentially helpful to have the index in the accessory anway...