### PR TITLE
Lower-case Boolean type synonym

### DIFF
--- a/src/_components/AnnotationsData.html.svelte
+++ b/src/_components/AnnotationsData.html.svelte
@@ -13,7 +13,7 @@
 	/** @type {Function} [getText=d => d.text] - An accessor function to get the field to display. */
 	export let getText = d => d.text;
 
-	/** @type {Boolean} [percentRange=false] - If `true` will set the `top` and `left` CSS positions to percentages instead of pixels. */
+	/** @type {boolean} [percentRange=false] - If `true` will set the `top` and `left` CSS positions to percentages instead of pixels. */
 	export let pr = $percentRange;
 
 	$: units = pr === true ? '%' : 'px';

--- a/src/_components/AxisX.percent-range.html.svelte
+++ b/src/_components/AxisX.percent-range.html.svelte
@@ -9,19 +9,19 @@
 
 	const { xScale, percentRange } = getContext('LayerCake');
 
-	/** @type {Boolean} [tickMarks=false] - Show a vertical mark for each tick. */
+	/** @type {boolean} [tickMarks=false] - Show a vertical mark for each tick. */
 	export let tickMarks = false;
 
-	/** @type {Boolean} [gridlines=true] - Show gridlines extending into the chart area. */
+	/** @type {boolean} [gridlines=true] - Show gridlines extending into the chart area. */
 	export let gridlines = true;
 
 	/** @type {Number} [tickMarkLength=6] - The length of the tick mark. */
 	export let tickMarkLength = 6;
 
-	/** @type {Boolean} [baseline=false] – Show a solid line at the bottom. */
+	/** @type {boolean} [baseline=false] – Show a solid line at the bottom. */
 	export let baseline = false;
 
-	/** @type {Boolean} [snapLabels=false] - Instead of centering the text labels on the first and the last items, align them to the edges of the chart. */
+	/** @type {boolean} [snapLabels=false] - Instead of centering the text labels on the first and the last items, align them to the edges of the chart. */
 	export let snapLabels = false;
 
 	/** @type {(d: any) => string} [format=d => d] - A function that passes the current tick value and expects a nicely formatted value in return. */

--- a/src/_components/AxisX.svelte
+++ b/src/_components/AxisX.svelte
@@ -7,19 +7,19 @@
 
 	const { width, height, xScale, yRange } = getContext('LayerCake');
 
-	/** @type {Boolean} [tickMarks=false] - Show a vertical mark for each tick. */
+	/** @type {boolean} [tickMarks=false] - Show a vertical mark for each tick. */
 	export let tickMarks = false;
 
-	/** @type {Boolean} [gridlines=true] - Show gridlines extending into the chart area. */
+	/** @type {boolean} [gridlines=true] - Show gridlines extending into the chart area. */
 	export let gridlines = true;
 
 	/** @type {Number} [tickMarkLength=6] - The length of the tick mark. */
 	export let tickMarkLength = 6;
 
-	/** @type {Boolean} [baseline=false] – Show a solid line at the bottom. */
+	/** @type {boolean} [baseline=false] – Show a solid line at the bottom. */
 	export let baseline = false;
 
-	/** @type {Boolean} [snapLabels=false] - Instead of centering the text labels on the first and the last items, align them to the edges of the chart. */
+	/** @type {boolean} [snapLabels=false] - Instead of centering the text labels on the first and the last items, align them to the edges of the chart. */
 	export let snapLabels = false;
 
 	/** @type {(d: any) => string} [format=d => d] - A function that passes the current tick value and expects a nicely formatted value in return. */
@@ -38,7 +38,7 @@
 	export let dy = 12;
 
 	/**@param {Number} i
-	 * @param {Boolean} sl */
+	 * @param {boolean} sl */
 	function textAnchor(i, sl) {
 		if (sl === true) {
 			if (i === 0) {

--- a/src/_components/AxisXTop.percent-range.html.svelte
+++ b/src/_components/AxisXTop.percent-range.html.svelte
@@ -9,19 +9,19 @@
 
 	const { xScale, percentRange } = getContext('LayerCake');
 
-	/** @type {Boolean} [tickMarks=false] - Show a vertical mark for each tick. */
+	/** @type {boolean} [tickMarks=false] - Show a vertical mark for each tick. */
 	export let tickMarks = false;
 
-	/** @type {Boolean} [gridlines=true] - Show gridlines extending into the chart area. */
+	/** @type {boolean} [gridlines=true] - Show gridlines extending into the chart area. */
 	export let gridlines = true;
 
 	/** @type {Number} [tickMarkLength=6] - The length of the tick mark. */
 	export let tickMarkLength = 6;
 
-	/** @type {Boolean} [baseline=false] – Show a solid line at the bottom. */
+	/** @type {boolean} [baseline=false] – Show a solid line at the bottom. */
 	export let baseline = false;
 
-	/** @type {Boolean} [snapLabels=false] - Instead of centering the text labels on the first and the last items, align them to the edges of the chart. */
+	/** @type {boolean} [snapLabels=false] - Instead of centering the text labels on the first and the last items, align them to the edges of the chart. */
 	export let snapLabels = false;
 
 	/** @type {(d: any) => string} [format=d => d] - A function that passes the current tick value and expects a nicely formatted value in return. */

--- a/src/_components/AxisXTop.svelte
+++ b/src/_components/AxisXTop.svelte
@@ -7,19 +7,19 @@
 
 	const { width, height, xScale, yRange } = getContext('LayerCake');
 
-	/** @type {Boolean} [tickMarks=false] - Show a vertical mark for each tick. */
+	/** @type {boolean} [tickMarks=false] - Show a vertical mark for each tick. */
 	export let tickMarks = false;
 
-	/** @type {Boolean} [gridlines=true] - Show gridlines extending into the chart area. */
+	/** @type {boolean} [gridlines=true] - Show gridlines extending into the chart area. */
 	export let gridlines = true;
 
 	/** @type {Number} [tickMarkLength=6] - The length of the tick mark. */
 	export let tickMarkLength = 6;
 
-	/** @type {Boolean} [baseline=false] – Show a solid line at the bottom. */
+	/** @type {boolean} [baseline=false] – Show a solid line at the bottom. */
 	export let baseline = false;
 
-	/** @type {Boolean} [snapLabels=false] - Instead of centering the text labels on the first and the last items, align them to the edges of the chart. */
+	/** @type {boolean} [snapLabels=false] - Instead of centering the text labels on the first and the last items, align them to the edges of the chart. */
 	export let snapLabels = false;
 
 	/** @type {(d: any) => string} [format=d => d] - A function that passes the current tick value and expects a nicely formatted value in return. */
@@ -38,7 +38,7 @@
 	export let dy = -4;
 
 	/**@param {Number} i
-	 * @param {Boolean} sl */
+	 * @param {boolean} sl */
 	function textAnchor(i, sl) {
 		if (sl === true) {
 			if (i === 0) {

--- a/src/_components/AxisY.percent-range.html.svelte
+++ b/src/_components/AxisY.percent-range.html.svelte
@@ -9,16 +9,16 @@
 
 	const { xRange, yScale, percentRange } = getContext('LayerCake');
 
-	/** @type {Boolean} [tickMarks=false] - Show marks next to the tick label. */
+	/** @type {boolean} [tickMarks=false] - Show marks next to the tick label. */
 	export let tickMarks = false;
 
 	/** @type {String} [labelPosition='even'] - Whether the label sits even with its value ('even') or sits on top ('above') the tick mark. Default is 'even'. */
 	export let labelPosition = 'even';
 
-	/** @type {Boolean} [snapBaselineLabel=false] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
+	/** @type {boolean} [snapBaselineLabel=false] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
 	export let snapBaselineLabel = false;
 
-	/** @type {Boolean} [gridlines=true] - Show gridlines extending into the chart area. */
+	/** @type {boolean} [gridlines=true] - Show gridlines extending into the chart area. */
 	export let gridlines = true;
 
 	/** @type {Number|undefined} [tickMarkLength=undefined] - The length of the tick mark. If not set, becomes the length of the widest tick. */

--- a/src/_components/AxisY.svelte
+++ b/src/_components/AxisY.svelte
@@ -7,16 +7,16 @@
 
 	const { xRange, yScale, width } = getContext('LayerCake');
 
-	/** @type {Boolean} [tickMarks=false] - Show marks next to the tick label. */
+	/** @type {boolean} [tickMarks=false] - Show marks next to the tick label. */
 	export let tickMarks = false;
 
 	/** @type {String} [labelPosition='even'] - Whether the label sits even with its value ('even') or sits on top ('above') the tick mark. Default is 'even'. */
 	export let labelPosition = 'even';
 
-	/** @type {Boolean} [snapBaselineLabel=false] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
+	/** @type {boolean} [snapBaselineLabel=false] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
 	export let snapBaselineLabel = false;
 
-	/** @type {Boolean} [gridlines=true] - Show gridlines extending into the chart area. */
+	/** @type {boolean} [gridlines=true] - Show gridlines extending into the chart area. */
 	export let gridlines = true;
 
 	/** @type {Number|undefined} [tickMarkLength=undefined] - The length of the tick mark. If not set, becomes the length of the widest tick. */

--- a/src/_components/AxisYRight.percent-range.html.svelte
+++ b/src/_components/AxisYRight.percent-range.html.svelte
@@ -9,16 +9,16 @@
 
 	const { xRange, yScale, width, percentRange } = getContext('LayerCake');
 
-	/** @type {Boolean} [tickMarks=true] - Show marks next to the tick label. */
+	/** @type {boolean} [tickMarks=true] - Show marks next to the tick label. */
 	export let tickMarks = true;
 
 	/** @type {String} [labelPosition='even'] - Whether the label sits even with its value ('even') or sits on top ('above') the tick mark. Default is 'even'. */
 	export let labelPosition = 'even';
 
-	/** @type {Boolean} [snapBaselineLabel=false] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
+	/** @type {boolean} [snapBaselineLabel=false] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
 	export let snapBaselineLabel = false;
 
-	/** @type {Boolean} [gridlines=true] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
+	/** @type {boolean} [gridlines=true] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
 	export let gridlines = true;
 
 	/** @type {Number|undefined} [tickMarkLength=undefined] - The length of the tick mark. If not set, becomes the length of the widest tick. */

--- a/src/_components/AxisYRight.svelte
+++ b/src/_components/AxisYRight.svelte
@@ -7,16 +7,16 @@
 
 	const { xRange, yScale, width } = getContext('LayerCake');
 
-	/** @type {Boolean} [tickMarks=false] - Show marks next to the tick label. */
+	/** @type {boolean} [tickMarks=false] - Show marks next to the tick label. */
 	export let tickMarks = false;
 
 	/** @type {String} [labelPosition='above'] - Whether the label sits even with its value ('even') or sits on top ('above') the tick mark. */
 	export let labelPosition = 'above';
 
-	/** @type {Boolean} [snapBaselineLabel=false] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
+	/** @type {boolean} [snapBaselineLabel=false] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
 	export let snapBaselineLabel = false;
 
-	/** @type {Boolean} [gridlines=true] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
+	/** @type {boolean} [gridlines=true] - When labelPosition='even', adjust the lowest label so that it sits above the tick mark. */
 	export let gridlines = true;
 
 	/** @type {Number|undefined} [tickMarkLength=undefined] - The length of the tick mark. If not set, becomes the length of the widest tick. */

--- a/src/_components/CirclePackForce.svelte
+++ b/src/_components/CirclePackForce.svelte
@@ -23,7 +23,7 @@
 	/** @type {Number} [nodeStrokeWidth=1] - The circle's stroke width, in pixels. */
 	export let nodeStrokeWidth = 1;
 
-	/** @type {Boolean} [groupBy=true] - Group the nodes by the return value of the x-scale. If `false`, align all the nodes to the canvas center. */
+	/** @type {boolean} [groupBy=true] - Group the nodes by the return value of the x-scale. If `false`, align all the nodes to the canvas center. */
 	export let groupBy = true;
 
 	/* --------------------------------------------

--- a/src/_components/Column.svelte
+++ b/src/_components/Column.svelte
@@ -16,7 +16,7 @@
 	/** @type {Number} [strokeWidth=0] - The shape's stroke width. */
 	export let strokeWidth = 0;
 
-	/** @type {Boolean} [false] - Show the numbers for each column */
+	/** @type {boolean} [false] - Show the numbers for each column */
 	export let showLabels = false;
 
 	$: columnWidth = d => {

--- a/src/_components/Key.html.svelte
+++ b/src/_components/Key.html.svelte
@@ -14,7 +14,7 @@
 	/** @type {Function|Object|undefined} [lookup] - Either a function that takes the value and returns a formatted string, or an object of values. If a given value is not present in a lookup object, it returns the original value. */
 	export let lookup = undefined;
 
-	/** @type {Boolean} [capitalize=true] - Capitalize the first character. */
+	/** @type {boolean} [capitalize=true] - Capitalize the first character. */
 	export let capitalize = true;
 
 	const { zDomain, zScale } = getContext('LayerCake');

--- a/src/content/guide/03-layercake-props.md
+++ b/src/content/guide/03-layercake-props.md
@@ -121,7 +121,7 @@ Same as [x](/guide#x) but for the z dimension.
 
 Same as [x](/guide#x) but for the r dimension.
 
-### debug `Boolean`
+### debug `boolean`
 
 If this is `true`, Layer Cake will print to the control a helpful debug message.
 
@@ -223,21 +223,21 @@ Same as [xDomain](/guide#xdomain) but for the z scale.
 
 Same as [xDomain](/guide#xdomain) but for the r scale.
 
-### xDomainSort `Boolean=true`
+### xDomainSort `boolean=true`
 
 Taken into account only when the x-scale is ordinal. It sets whether the calculated unique items come back sorted. It uses [d3.ascending](https://d3js.org/d3-array/sort#ascending) to do the sort calculation.
 
 Set this to `false` if you want the unique items to appear in the order they were found in the data.
 
-### yDomainSort `Boolean=true`
+### yDomainSort `boolean=true`
 
 Same as [xDomainSort](/guide#xdomainsort) but for the y domain.
 
-### zDomainSort `Boolean=true`
+### zDomainSort `boolean=true`
 
 Same as [xDomainSort](/guide#xdomainsort) but for the z domain.
 
-### rDomainSort `Boolean=true`
+### rDomainSort `boolean=true`
 
 Same as [xDomainSort](/guide#xdomainsort) but for the r domain.
 
@@ -265,19 +265,19 @@ Same as [xPadding](/guide#xpadding) but for the z domain.
 
 Same as [xPadding](/guide#xpadding) but for the r domain.
 
-### xNice `Boolean=false|Number`
+### xNice `boolean=false|Number`
 
 Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the x domain. This is a separate option instead of being one you can apply to a passed in scale because D3's "nice" transformation only works on existing domains and does not use a state to be able to tell if your existing scale wants to be nice. Can also pass `count` number as argument for greater control.
 
-### yNice `Boolean=false|Number`
+### yNice `boolean=false|Number`
 
 Same as [xNice](/guide#xnice) but for the y domain.
 
-### zNice `Boolean=false|Number`
+### zNice `boolean=false|Number`
 
 Same as [xNice](/guide#xnice) but for the z domain.
 
-### rNice `Boolean=false|Number`
+### rNice `boolean=false|Number`
 
 Same as [xNice](/guide#xnice) but for the r domain.
 
@@ -319,25 +319,25 @@ Same as [xRange](/guide#xrange) but for the r scale. Override the default y rang
 
 This overrides setting [rReverse](/guide#rreverse) to `true`.
 
-### xReverse `Boolean=false`
+### xReverse `boolean=false`
 
 Reverse the default x range. By default this is `false` and the range is `[0, width]`.
 
 This is ignored if you set [xRange](/guide#xrange).
 
-### yReverse `Boolean=true`
+### yReverse `boolean=true`
 
 Reverse the default y range. By default this is `true` and the range is `[height, 0]` unless using `scaleBand` for yScale in which case this is `false`.
 
 This is ignored if you set [yRange](/guide#yrange).
 
-### zReverse `Boolean=false`
+### zReverse `boolean=false`
 
 Reverse the default z range. By default this is `false` and the range is `[0, width]`.
 
 This is ignored if you set [zRange](/guide#zrange).
 
-### rReverse `Boolean=false`
+### rReverse `boolean=false`
 
 Reverse the default r range. By default this is `false` and the range is `[1, 25]`.
 
@@ -409,13 +409,13 @@ Here's an example showing passing different data formats for extent calculation 
 </style>
 ```
 
-### ssr `Boolean=false`
+### ssr `boolean=false`
 
 Set whether this chart should be rendered server side. This is best used in conjunction with the [ScaledSvg](guide#scaledsvg) component or HTML components that are set to use percentage scales since you won't know the size of the container at render time.
 
 Use it in conjunction with [`percentRange={true}`](guide#percentrange) to easily set up your scales for a percent coordinate systems.
 
-### percentRange `Boolean=false`
+### percentRange `boolean=false`
 
 When rendering charts server side, you pretty much always want your scale range to be `[0, 100]` since you won't be able to base the range off of the target container's width. Use this convenience helper to set the ranges for any field that has an accessor to just that.
 

--- a/src/content/guide/06-layout-component-props.md
+++ b/src/content/guide/06-layout-component-props.md
@@ -5,7 +5,7 @@ title: Layout component props
 In addition to the [accessibility props](guide#accessibility) described above, all layout components accept the following props:
 
 - [zIndex](guide#zindex) `Number|String`
-- [pointerEvents](guide#pointerevents) `Boolean`
+- [pointerEvents](guide#pointerevents) `boolean`
 
 The Svg and ScaledSvg layout components also accept:
 
@@ -62,7 +62,7 @@ This lets you fine-tune your layering and is useful if you want your layers to b
 </LayerCake>
 ```
 
-### pointerEvents `Boolean|undefined`
+### pointerEvents `boolean|undefined`
 
 Useful for tooltip layers that need to be display above chart elements but not capture mouse events. Defaults to no `pointer-events` CSS being set. Set to `false` to set `pointer-events: none;`
 

--- a/src/content/guide/99-helper-functions.md
+++ b/src/content/guide/99-helper-functions.md
@@ -96,7 +96,7 @@ console.log(extents);
 */
 ```
 
-### calcUniques(flatData: `Array`, fields: `{x?: Function, y?: Function, z?: Function, r?: Function}`[, sortOptions: { sort: `Boolean`, x: `Boolean`, y: `Boolean`, z: `Boolean`, r: `Boolean` }])
+### calcUniques(flatData: `Array`, fields: `{x?: Function, y?: Function, z?: Function, r?: Function}`[, sortOptions: { sort: `boolean`, x: `boolean`, y: `boolean`, z: `boolean`, r: `boolean` }])
 
 The same API and behavior as `calcExtents` but instead of a two-value array of `[min, max]` values, it returns an array of unique items.
 
@@ -495,7 +495,7 @@ stack(data, ['apples', 'bananas', 'cherries', 'dates'])
 ]
 ```
 
-### uniques(data: `Array`[, accessor: `String|Function`, transform: `Boolean=true`])
+### uniques(data: `Array`[, accessor: `String|Function`, transform: `boolean=true`])
 
 A function to get the unique values from a list. If **accessor** is specified, the uniqueness will be compared using that and, by default, the values in the returned list of unique values will be values returned by the accessor. Accessor can also be the string name of the key. Pass `false` to the **transform** argument if you want to return the original elements, which will be the first one that appears for every unique value. The default for **transform** is `true`.
 

--- a/src/lib/LayerCake.svelte
+++ b/src/lib/LayerCake.svelte
@@ -21,13 +21,13 @@
 
 	const printDebug_debounced = debounce(printDebug, 200);
 
-	/** @type {Boolean} [ssr=false] Whether this chart should be rendered server side. */
+	/** @type {boolean} [ssr=false] Whether this chart should be rendered server side. */
 	export let ssr = false;
-	/** @type {Boolean} [pointerEvents=true] Whether to allow pointer events via CSS. Set this to `false` to set `pointer-events: none;` on all components, disabling all mouse interaction. */
+	/** @type {boolean} [pointerEvents=true] Whether to allow pointer events via CSS. Set this to `false` to set `pointer-events: none;` on all components, disabling all mouse interaction. */
 	export let pointerEvents = true;
 	/** @type {String} [position='relative'] Determine the positioning of the wrapper div. Set this to `'absolute'` when you want to stack cakes. */
 	export let position = 'relative';
-	/** @type {Boolean} [percentRange=false] If `true`, set all scale ranges to `[0, 100]`. Ranges reversed via `xReverse`, `yReverse`, `zReverse` or `rReverse` props will continue to be reversed as usual. */
+	/** @type {boolean} [percentRange=false] If `true`, set all scale ranges to `[0, 100]`. Ranges reversed via `xReverse`, `yReverse`, `zReverse` or `rReverse` props will continue to be reversed as usual. */
 	export let percentRange = false;
 
 	/** @type {Number} [width=containerWidth] Override the automated width. */
@@ -70,13 +70,13 @@
 	export let zDomain = undefined;
 	/** @type {[min: Number|null, max: Number|null]|Array<String|Number>|Function|undefined} [rDomain] Set a min or max. For linear scales, if you want to inherit the value from the data's extent, set that value to `null`. This value can also be an array because sometimes your scales are [piecewise](https://github.com/d3/d3-scale#continuous_domain) or are a list of discrete values such as in [ordinal scales](https://github.com/d3/d3-scale#ordinal-scales), useful for color series. Set it to a function that receives the computed domain and lets you return a modified domain, useful for sorting values. */
 	export let rDomain = undefined;
-	/** @type {Boolean|Number} [xNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the x domain. */
+	/** @type {boolean|Number} [xNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the x domain. */
 	export let xNice = false;
-	/** @type {Boolean|Number} [yNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the y domain. */
+	/** @type {boolean|Number} [yNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the y domain. */
 	export let yNice = false;
-	/** @type {Boolean|Number} [zNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the z domain. */
+	/** @type {boolean|Number} [zNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the z domain. */
 	export let zNice = false;
-	/** @type {Boolean} [rNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the r domain. */
+	/** @type {boolean} [rNice=false] Applies D3's [scale.nice()](https://github.com/d3/d3-scale#continuous_nice) to the r domain. */
 	export let rNice = false;
 	/** @type {[leftPixels: Number, rightPixels: Number]|undefined} [xPadding] Assign a pixel value to add to the min or max of the scale. This will increase the scales domain by the scale unit equivalent of the provided pixels. */
 	export let xPadding = undefined;
@@ -102,21 +102,21 @@
 	export let zRange = undefined;
 	/** @type {[min: Number, max: Number]|Function|Array<String|Number>|undefined} [rRange] Override the default r range of `[1, 25]` by setting an array or function with argument `({ width, height})` that returns an array. Setting this prop overrides `rReverse`. This can also be a list of numbers or strings for scales with discrete ranges like [scaleThreshhold](https://github.com/d3/d3-scale#threshold-scales) or [scaleQuantize](https://github.com/d3/d3-scale#quantize-scales). */
 	export let rRange = undefined;
-	/** @type {Boolean} [xReverse=false] Reverse the default x range. By default this is `false` and the range is `[0, width]`. Ignored if you set the xRange prop. */
+	/** @type {boolean} [xReverse=false] Reverse the default x range. By default this is `false` and the range is `[0, width]`. Ignored if you set the xRange prop. */
 	export let xReverse = false;
-	/** @type {Boolean|undefined} [yReverse=true] Reverse the default y range. By default this is set dynamically and will be `true` – setting the range to `[height, 0]` – unless the `yScale` has a `.bandwidth` method. Dynamic behavior is overridden if the user sets the prop. Ignored if you set the `yRange` prop. */
+	/** @type {boolean|undefined} [yReverse=true] Reverse the default y range. By default this is set dynamically and will be `true` – setting the range to `[height, 0]` – unless the `yScale` has a `.bandwidth` method. Dynamic behavior is overridden if the user sets the prop. Ignored if you set the `yRange` prop. */
 	export let yReverse = undefined;
-	/** @type {Boolean} [zReverse=false] Reverse the default z range. By default this is `false` and the range is `[0, width]`. Ignored if you set the zRange prop. */
+	/** @type {boolean} [zReverse=false] Reverse the default z range. By default this is `false` and the range is `[0, width]`. Ignored if you set the zRange prop. */
 	export let zReverse = false;
-	/** @type {Boolean} [rReverse=false] Reverse the default r range. By default this is `false` and the range is `[1, 25]`. Ignored if you set the rRange prop. */
+	/** @type {boolean} [rReverse=false] Reverse the default r range. By default this is `false` and the range is `[1, 25]`. Ignored if you set the rRange prop. */
 	export let rReverse = false;
-	/** @type {Boolean} [xDomainSort=true] Only used when scale is ordinal. Set whether the calculated unique items come back sorted. */
+	/** @type {boolean} [xDomainSort=true] Only used when scale is ordinal. Set whether the calculated unique items come back sorted. */
 	export let xDomainSort = true;
-	/** @type {Boolean} [yDomainSort=true] Only used when scale is ordinal. Set whether the calculated unique items come back sorted. */
+	/** @type {boolean} [yDomainSort=true] Only used when scale is ordinal. Set whether the calculated unique items come back sorted. */
 	export let yDomainSort = true;
-	/** @type {Boolean} [zDomainSort=true] Only used when scale is ordinal. Set whether the calculated unique items come back sorted. */
+	/** @type {boolean} [zDomainSort=true] Only used when scale is ordinal. Set whether the calculated unique items come back sorted. */
 	export let zDomainSort = true;
-	/** @type {Boolean} [rDomainSort=true] Only used when scale is ordinal. Set whether the calculated unique items come back sorted. */
+	/** @type {boolean} [rDomainSort=true] Only used when scale is ordinal. Set whether the calculated unique items come back sorted. */
 	export let rDomainSort = true;
 	/** @type {{top?: Number, right?: Number, bottom?: Number, left?: Number}} [padding={}] The amount of padding to put around your chart. It operates like CSS box-sizing: border-box; where values are subtracted from the parent container's width and height, the same as a [D3 margin convention](https://bl.ocks.org/mbostock/3019563). */
 	export let padding = {};
@@ -129,9 +129,9 @@
 	/** @type {Object} custom Any extra configuration values you want available on the LayerCake context. This could be useful for color lookups or additional constants. */
 	export let custom = {};
 
-	/** @type {Boolean} debug Enable debug printing to the console. Useful to inspect your scales and dimensions. */
+	/** @type {boolean} debug Enable debug printing to the console. Useful to inspect your scales and dimensions. */
 	export let debug = false;
-	/** @type {Boolean} [verbose=true] Show warnings in the console. */
+	/** @type {boolean} [verbose=true] Show warnings in the console. */
 	export let verbose = true;
 
 	/**

--- a/src/lib/helpers/isOrdinalDomain.js
+++ b/src/lib/helpers/isOrdinalDomain.js
@@ -4,7 +4,7 @@ import arraysEqual from '../utils/arraysEqual.js';
   Determine whether a scale has an ordinal domain
 	https://svelte.dev/repl/ec6491055208401ca41120c9c8a67737?version=3.49.0
 	@param {Function} scale A D3 scale
-	@returns {Boolean} Whether the scale is an ordinal scale
+	@returns {boolean} Whether the scale is an ordinal scale
  */
 export default function isOrdinalDomain(scale) {
 	// scaleBand, scalePoint

--- a/src/lib/layouts/Canvas.svelte
+++ b/src/lib/layouts/Canvas.svelte
@@ -18,7 +18,7 @@
 	/** @type {Number|undefined} [zIndex] The layer's z-index. */
 	export let zIndex = undefined;
 
-	/** @type {Boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
+	/** @type {boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
 	export let pointerEvents = undefined;
 
 	/** @type {String} [fallback] Text to display if the browser won't render a canvas tag. You can also set arbitrary HTML via the "fallback" slot but this is fine if you just need text. If you use the "fallback" slot, this prop is ignored. */

--- a/src/lib/layouts/Html.svelte
+++ b/src/lib/layouts/Html.svelte
@@ -13,7 +13,7 @@
 	/** @type {Number|undefined} [zIndex] The layer's z-index. */
 	export let zIndex = undefined;
 
-	/** @type {Boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
+	/** @type {boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
 	export let pointerEvents = undefined;
 
 	/** @type {String|undefined} [role] A string passed to the `aria-role` on the `<div>` tag. This is `undefined` by default but will be set by default to `'figure'` if `label`, `labelledby` or `describedby` is set. That default will be overridden by whatever is passed in. */

--- a/src/lib/layouts/ScaledSvg.svelte
+++ b/src/lib/layouts/ScaledSvg.svelte
@@ -13,7 +13,7 @@
 	/** @type {Number|undefined} [zIndex] The layer's z-index. */
 	export let zIndex = undefined;
 
-	/** @type {Boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
+	/** @type {boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
 	export let pointerEvents = undefined;
 
 	/** @type {Number} [fixedAspectRatio=1] A number to set the aspect ratio onto the viewBox. */

--- a/src/lib/layouts/Svg.svelte
+++ b/src/lib/layouts/Svg.svelte
@@ -14,7 +14,7 @@
 	/** @type {Number|undefined} [zIndex] The layer's z-index. */
 	export let zIndex = undefined;
 
-	/** @type {Boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
+	/** @type {boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
 	export let pointerEvents = undefined;
 
 	/** @type {String|undefined} [viewBox] A string passed to the `viewBox` property on the `<svg>` tag. */

--- a/src/lib/layouts/Webgl.svelte
+++ b/src/lib/layouts/Webgl.svelte
@@ -12,7 +12,7 @@
 	/** @type {Number|undefined} [zIndex] The layer's z-index. */
 	export let zIndex = undefined;
 
-	/** @type {Boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
+	/** @type {boolean|undefined} [pointerEvents] Set this to `false` to set `pointer-events: none;` on the entire layer. */
 	export let pointerEvents = undefined;
 
 	/** @type {Object|undefined} [contextAttributes] The second argument passed to canvas.getContext. See the WebGL docs [for more info](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext). */

--- a/src/lib/lib/calcUniques.js
+++ b/src/lib/lib/calcUniques.js
@@ -10,7 +10,7 @@ import { ascending, InternSet } from 'd3-array';
 	`{ x: [0, 10, 5], y: [-10, 0, 10] }`
 	@param {Array} data A flat array of.
 	@param {{x?: Function, y?: Function, z?: Function, r?: Function}} fields An object containing `x`, `y`, `r` or `z` keys that equal an accessor function. If an accessor function returns an array of values, each value will also be evaluated.
-	@param {{ sort?: Boolean, x?: Boolean , y?: Boolean , z?: Boolean , r?: Boolean }} sortOptions An object containing `sort`, `x`, `y`, `r` or `z` keys with Boolean values that designate how results should be sorted. Default is un-sorted. Pass in `sort: true` to sort all fields or specify fields individually.
+	@param {{ sort?: boolean, x?: boolean , y?: boolean , z?: boolean , r?: boolean }} sortOptions An object containing `sort`, `x`, `y`, `r` or `z` keys with boolean values that designate how results should be sorted. Default is un-sorted. Pass in `sort: true` to sort all fields or specify fields individually.
 	@returns {{x?: [min: Number, max: Number]|[min: String, max: String], y?: [min: Number, max: Number]|[min: String, max: String], z?: [min: Number, max: Number]|[min: String, max: String], r?: [min: Number, max: Number]|[min: String, max: String]}} An object with the same structure as `fields` but instead of an accessor, each key contains an array of unique items.
 */
 export default function calcUniques(data, fields, sortOptions = {}) {

--- a/src/lib/lib/uniques.js
+++ b/src/lib/lib/uniques.js
@@ -2,7 +2,7 @@
 	Remove duplicate values from a list with an optional iterator string or function. By default return the transformed value if iteratee exists.
 	@param {Array} list An array of values or objects.
 	@param {String|Function} [accessor] An optional accessor function that takes an object and returns the value to judge uniqueness by. If accessor is a string instead of a function, judges uniqueness by the property named by accessor on each of the objects.
-	@param {Boolean} [transform=true] If true, return the transformed value from accessor.
+	@param {boolean} [transform=true] If true, return the transformed value from accessor.
 	@returns {Array}
 */
 

--- a/src/lib/utils/arraysEqual.js
+++ b/src/lib/utils/arraysEqual.js
@@ -5,7 +5,7 @@
 	of making a set
 	@param {Array} arr1 An array to test
 	@param {Array} arr2 An array to test against
-	@returns {Boolean} Whether they contain all and only the same items
+	@returns {boolean} Whether they contain all and only the same items
  */
 export default function arraysEqual(arr1, arr2) {
 	if (arr1.length !== arr2.length) return false;


### PR DESCRIPTION
See discussion in #218

While 'Boolean' is a valid JSDoc type synonym the lower-case variant is used to avoid confusion.