### PR TITLE
Add type information for mousemove event

### DIFF
--- a/src/_components/QuadTree.html.svelte
+++ b/src/_components/QuadTree.html.svelte
@@ -14,10 +14,10 @@
 	let found = {};
 	let e = {};
 
-	/** @type {String} [x='x'] – The dimension to search across when moving the mouse left and right. */
+	/** @type {'x'|'y'} [x='x'] – The dimension to search across when moving the mouse left and right. */
 	export let x = 'x';
 
-	/** @type {String} [y='y'] – The dimension to search across when moving the mouse up and down. */
+	/** @type {'x'|'y'} [y='y'] – The dimension to search across when moving the mouse up and down. */
 	export let y = 'y';
 
 	/** @type {Number|undefined} [searchRadius] – The number of pixels to search around the mouse's location. This is the third argument passed to [`quadtree.find`](https://github.com/d3/d3-quadtree#quadtree_find) and by default a value of `undefined` means an unlimited range. */
@@ -29,12 +29,13 @@
 	$: xGetter = x === 'x' ? $xGet : $yGet;
 	$: yGetter = y === 'y' ? $yGet : $xGet;
 
+	/** @param {MouseEvent} evt */
 	function findItem(evt) {
 		e = evt;
 
-		const xLayerKey = `layer${x.toUpperCase()}`;
-		const yLayerKey = `layer${y.toUpperCase()}`;
-
+		const xLayerKey = /** @type {'layerX'|'layerY'} */ (`layer${x.toUpperCase()}`);
+		const yLayerKey = /** @type {'layerX'|'layerY'}*/ (`layer${y.toUpperCase()}`);
+		console.log(evt.x, evt.y);
 		found = finder.find(evt[xLayerKey], evt[yLayerKey], searchRadius) || {};
 		visible = Object.keys(found).length > 0;
 	}

--- a/src/_components/QuadTree.html.svelte
+++ b/src/_components/QuadTree.html.svelte
@@ -35,7 +35,7 @@
 
 		const xLayerKey = /** @type {'layerX'|'layerY'} */ (`layer${x.toUpperCase()}`);
 		const yLayerKey = /** @type {'layerX'|'layerY'}*/ (`layer${y.toUpperCase()}`);
-		console.log(evt.x, evt.y);
+
 		found = finder.find(evt[xLayerKey], evt[yLayerKey], searchRadius) || {};
 		visible = Object.keys(found).length > 0;
 	}

--- a/src/_components/QuadTree.percent-range.html.svelte
+++ b/src/_components/QuadTree.percent-range.html.svelte
@@ -14,10 +14,10 @@
 	let found = {};
 	let e = {};
 
-	/** @type {String} [x='x'] - The dimension to search across when moving the mouse left and right. */
+	/** @type {'x'|'y'} [x='x'] - The dimension to search across when moving the mouse left and right. */
 	export let x = 'x';
 
-	/** @type {String} [y='y'] - The dimension to search across when moving the mouse up and down. */
+	/** @type {'x'|'y'} [y='y'] - The dimension to search across when moving the mouse up and down. */
 	export let y = 'y';
 
 	/** @type {Number|undefined} [searchRadius] - The number of pixels to search around the mouse's location. This is the third argument passed to [`quadtree.find`](https://github.com/d3/d3-quadtree#quadtree_find) and by default a value of `undefined` means an unlimited range. */
@@ -29,11 +29,12 @@
 	$: xGetter = x === 'x' ? $xGet : $yGet;
 	$: yGetter = y === 'y' ? $yGet : $xGet;
 
+	/** @param {MouseEvent} evt*/
 	function findItem(evt) {
 		e = evt;
 
-		const xLayerKey = `layer${x.toUpperCase()}`;
-		const yLayerKey = `layer${y.toUpperCase()}`;
+		const xLayerKey = /** @type {'layerX'|'layerY'} */ (`layer${x.toUpperCase()}`);
+		const yLayerKey = /** @type {'layerX'|'layerY'}*/ (`layer${y.toUpperCase()}`);
 
 		const xLayerVal = (evt[xLayerKey] / (x === 'x' ? $width : $height)) * 100;
 		const yLayerVal = (evt[yLayerKey] / (y === 'y' ? $height : $width)) * 100;


### PR DESCRIPTION
This adds type information for the mousemove event in the Quadtree components. The error was:

```
src/_components/QuadTree.html.svelte:32:20
Error: Parameter 'evt' implicitly has an 'any' type. (js)

	function findItem(evt) {
		e = evt;
--
src/_components/QuadTree.percent-range.html.svelte:32:20
Error: Parameter 'evt' implicitly has an 'any' type. (js)

	function findItem(evt) {
		e = evt;
```

This also adds a JSDoc typecast for the 'layerX'/'layerY' values which probably is an example of those type annotations you didn't like so much (and me neither).
I didn't find another way to let the checking accept the uppercase conversion in `layer${x.toUpperCase()` as a type of `'layerX'|'layerY'`. 