### PR TITLE
Add types to range calculation functions

### DIFF
--- a/src/lib/settings/getDefaultRange.js
+++ b/src/lib/settings/getDefaultRange.js
@@ -1,3 +1,10 @@
+/**
+ * @param {'x'|'y'|'z'|'r'} s
+ * @param {number} width
+ * @param {number} height
+ * @param {boolean} reverse
+ * @param {boolean} percentRange
+ */
 function calcBaseRange(s, width, height, reverse, percentRange) {
 	let min;
 	let max;
@@ -11,6 +18,14 @@ function calcBaseRange(s, width, height, reverse, percentRange) {
 	return reverse === true ? [max, min] : [min, max];
 }
 
+/**
+ * @param {'x'|'y'|'z'|'r'} s
+ * @param {number} width
+ * @param {number} height
+ * @param {boolean} reverse
+ * @param {[number, number]|Function|null} range
+ * @param {boolean} percentRange
+ */
 export default function getDefaultRange(s, width, height, reverse, range, percentRange) {
 	return !range
 		? calcBaseRange(s, width, height, reverse, percentRange)


### PR DESCRIPTION
Maybe the `s` parameter should only be `y` or `r`?