### PR TITLE
Remove half-working ARIA code and A11Y warning

### DIFF
--- a/src/_components/Brush.html.svelte
+++ b/src/_components/Brush.html.svelte
@@ -91,6 +91,7 @@
 	$: right = 100 * (1 - max);
 </script>
 
+<!-- TODO Add keyboard accessibility. See https://github.com/mhkeller/layercake/pull/258 -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	bind:this={brush}

--- a/src/_components/Brush.html.svelte
+++ b/src/_components/Brush.html.svelte
@@ -91,16 +91,12 @@
 	$: right = 100 * (1 - max);
 </script>
 
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	bind:this={brush}
 	class="brush-outer"
 	on:mousedown|stopPropagation={reset}
 	on:touchstart|stopPropagation={reset}
-	role="slider"
-	aria-valuemin={min}
-	aria-valuemax={max}
-	aria-valuetext="{min} to {max}"
-	tabindex="0"
 >
 	{#if min !== null}
 		<div
@@ -108,33 +104,18 @@
 			on:mousedown|stopPropagation={move}
 			on:touchstart|stopPropagation={move}
 			style="left: {left}%; right: {right}%"
-			role="slider"
-			aria-valuemin={min}
-			aria-valuemax={max}
-			aria-valuetext="{min} to {max}"
-			tabindex="0"
 		></div>
 		<div
 			class="brush-handle"
 			on:mousedown|stopPropagation={adjust_min}
 			on:touchstart|stopPropagation={adjust_min}
 			style="left: {left}%"
-			role="slider"
-			aria-valuemin={min}
-			aria-valuemax={max}
-			aria-valuetext="{min} to {max}"
-			tabindex="0"
 		></div>
 		<div
 			class="brush-handle"
 			on:mousedown|stopPropagation={adjust_max}
 			on:touchstart|stopPropagation={adjust_max}
 			style="right: {right}%"
-			role="slider"
-			aria-valuemin={min}
-			aria-valuemax={max}
-			aria-valuetext="{min} to {max}"
-			tabindex="0"
 		></div>
 	{/if}
 </div>


### PR DESCRIPTION
While looking at converting components to Svelte 5 syntax I saw some warnings in the current versions.
 
For the Bruch component, running `svelte-check` reports a missing `aria-valuenow` attribute for the range slider which only has lower and upper value and no actual 'value', so maybe the role 'slider' is not applicable.

```js
/src/_components/Brush.html.svelte:99:2
Warn: Elements with the ARIA role "slider" must have the following attributes defined: "aria-valuenow" (svelte)
	on:touchstart|stopPropagation={reset}
	role="slider"
	aria-valuemin={min}


./src/_components/Brush.html.svelte:111:4
Warn: Elements with the ARIA role "slider" must have the following attributes defined: "aria-valuenow" (svelte)
			style="left: {left}%; right: {right}%"
			role="slider"
			aria-valuemin={min}


./src/_components/Brush.html.svelte:122:4
Warn: Elements with the ARIA role "slider" must have the following attributes defined: "aria-valuenow" (svelte)
			style="left: {left}%"
			role="slider"
			aria-valuemin={min}


./src/_components/Brush.html.svelte:133:4
Warn: Elements with the ARIA role "slider" must have the following attributes defined: "aria-valuenow" (svelte)
			style="right: {right}%"
			role="slider"
			aria-valuemin={min}
```

The current code wasn't actually keyboard accessible, so one could tab to the component but not change the values with the keyboard.

![image](https://github.com/user-attachments/assets/0aa1db82-96f6-41fc-8e0c-7a07d245fe2f)


I'd suggest to remove the code for now and silence the warning. It's probably better to have no keyboard accessibility than a half-working one.