### PR TITLE
Add aria-label to GitHub icon link

### DIFF
--- a/src/routes/_site-components/Nav.svelte
+++ b/src/routes/_site-components/Nav.svelte
@@ -120,6 +120,7 @@
 				target="_blank"
 				rel="noreferrer"
 				href="https://github.com/mhkeller/layercake"
+				aria-label="Layer Cake GitHub Repository"
 			>
 			</a>
 		</li>


### PR DESCRIPTION
Warning was:
> src/routes/_site-components/Nav.svelte:118:3 Buttons and links should either contain text or have an `aria-label` or `aria-labelledby` attribute https://svelte.dev/e/a11y_consider_explicit_label

I wasn't sure whether it should describe the logo or the link target, but it seems to be the target:

https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA8