### PR TITLE
Improve percentRange docstring in AnnotationsData component

### DIFF
--- a/src/_components/AnnotationsData.html.svelte
+++ b/src/_components/AnnotationsData.html.svelte
@@ -13,7 +13,7 @@
 	/** @type {Function} [getText=d => d.text] - An accessor function to get the field to display. */
 	export let getText = d => d.text;
 
-	/** @type {boolean} [percentRange=false] - If `true` will set the `top` and `left` CSS positions to percentages instead of pixels. */
+	/** @type {boolean} [pr=false] - If `true` will set the `top` and `left` CSS positions to percentages instead of pixels. */
 	export let pr = $percentRange;
 
 	$: units = pr === true ? '%' : 'px';


### PR DESCRIPTION
Just a tiny thing I spotted while working on Svelte 5 conversions.

The JSDoc string should be `pr` here I think:

```js
  /** @type {boolean} [percentRange=false] - If `true` will set the `top` and `left` CSS positions to percentages instead of pixels. */
  export let pr = $percentRange;

  $: units = pr === true ? '%' : 'px';
```

I'm not sure whether the `false` default is correct (probably indirectly from the `$percentRange` default value.