### PR TITLE
Only run the doc build and deployment in the main repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository == 'mhkeller/layercake'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
This avoids build errors in forks which can't (and probably shouldn't) deploy the docs. 

It's hard to test but I used something similar in another project.