### PR TITLE
Add workflow to update Playwright snapshots

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,0 +1,57 @@
+name: Update Playwright Snapshots
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-snapshots:
+    runs-on: ubuntu-24.04
+    container:
+      # https://playwright.dev/docs/docker
+      image: mcr.microsoft.com/playwright:v1.54.0-noble
+      options: --user 1001
+
+    if: github.ref_name != github.event.repository.default_branch
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Initialise Playwright tests
+        run: npm run pretest:playwright
+
+      - name: Update snapshots
+        run: npm run test:init:snapshots
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Get changed files
+        id: changed_files
+        run: |
+          files=$(git status --porcelain | awk '{print $2}' | grep '\.png$' || true)
+          echo "files=$files" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.changed_files.outputs.files != ''
+        run: |
+          git add -A test/e2e/**/*.png
+          git commit -m "Update Playwright snapshots"
+          git push origin ${{ github.ref_name }}


### PR DESCRIPTION
This adds a workflow to manually update snapshots on a PR branch after a desired change. This should ensure that the changes use the same Docker image/environment as tests later.

One needs to click in the Actions tab and select the branch.

<img width="386" height="219" alt="image" src="https://github.com/user-attachments/assets/b5864302-c94c-4234-ae3f-13c30c46c25b" />

You can see my test of the workflow here:

https://github.com/rgieseke/layercake/pull/5

Sorry again for the PRs I accidentally started in this repo while testing!

It would be nice to add some output (something for later maybe), but the PR comments were not working because the run is not directly attached to a PR.
Currently the changes are only viewable in the diff.