### PR TITLE
Remove `$:` from setting context

### DIFF
--- a/src/lib/LayerCake.svelte
+++ b/src/lib/LayerCake.svelte
@@ -50,7 +50,6 @@
 	 *
 	 */
 
-
 	/** @type {string|Function|number|Array<string|Function|number>|undefined} x The x accessor. The key in each row of data that corresponds to the x-field. This can be a string, an accessor function, a number or an array of any combination of those types. This property gets converted to a function when you access it through the context. */
 	export let x = undefined;
 	/** @type {string|Function|number|Array<string|Function|number>|undefined} y The y accessor. The key in each row of data that corresponds to the y-field. This can be a string, an accessor function, a number or an array of any combination of those types. This property gets converted to a function when you access it through the context. */
@@ -458,7 +457,7 @@
 		return $width / $height;
 	});
 
-	$: context = {
+	const context = {
 		activeGetters: activeGetters_d,
 		width: width_d,
 		height: height_d,
@@ -510,7 +509,7 @@
 		rGet: rGet_d
 	};
 
-	$: setContext('LayerCake', context);
+	setContext('LayerCake', context);
 
 	$: if ($box_d && debug === true && (ssr === true || typeof window !== 'undefined')) {
 		// Call this as a debounce so that it doesn't get called multiple times as these vars get filled in


### PR DESCRIPTION
In the new Svelte 5 async mode, these reactive statements cause the error

> set_context_after_init setContext must be called when a component first initializes, not in a subsequent effect or after an await expression https://svelte.dev/e/set_context_after_init in in LayerCake.svelte in App.svelte in __wrapper.svelte

I think these statements were a bit of overkill to begin with and they aren't necessary. This is going in as a final patch version to the pre-runes PR https://github.com/mhkeller/layercake/pull/271