### PR TITLE
Fix component names in markdown docs

### DIFF
--- a/src/content/examples-ssr/SmallMultiples.md
+++ b/src/content/examples-ssr/SmallMultiples.md
@@ -1,1 +1,1 @@
-An example of how to do small multiples with the same rendering component. Because we want to calculate and store the extents for each series, we have to put the Layer Cake component in a wrapper component, called `ChartWrapper.svelte` below.
+An example of how to do small multiples with the same rendering component. Because we want to calculate and store the extents for each series, we have to put the Layer Cake component in a wrapper component, called `SmallMultipleWrapper.percent-range.svelte` below.

--- a/src/content/examples/SmallMultiples.md
+++ b/src/content/examples/SmallMultiples.md
@@ -1,1 +1,1 @@
-An example of how to do small multiples with the same rendering component. Because we want to calculate and store the extents for each series, we have to put the Layer Cake component in a wrapper component, called `ChartWrapper.svelte` below.
+An example of how to do small multiples with the same rendering component. Because we want to calculate and store the extents for each series, we have to put the Layer Cake component in a wrapper component, called `SmallMultipleWrapper.svelte` below.


### PR DESCRIPTION
Just a tiny component rename in the Markdown docs.