### PR TITLE
Fix tooltip errors

### DIFF
--- a/src/routes/_components/Tooltip.html.svelte
+++ b/src/routes/_components/Tooltip.html.svelte
@@ -60,7 +60,7 @@
 					tooltipEvent = event;
 				}}
 				onmouseout={() => {
-					tooltipFeatures = null;
+					tooltipFeature = null;
 					tooltipEvent = null;
 				}}
 			/>

--- a/src/routes/_components/Tooltip.html.svelte
+++ b/src/routes/_components/Tooltip.html.svelte
@@ -32,6 +32,7 @@
 		Object.assign(d.properties, dataLookup.get(d.properties[joinKey]));
 	});
 
+	/** @type {MouseEvent | null} */
 	let tooltipEvent = $state(null);
 	let tooltipFeature = $state(null);
 


### PR DESCRIPTION
This fixes a typo in `tooltipFeature` which left the tooltip open on mouseout (https://layercake.graphics/components/Tooltip.html.svelte).

Also adds a type definition to silence a TypeScript error for `tooltipEvent`.

```
src/routes/_components/Tooltip.html.svelte:60:6
Error: Type 'MouseEvent' is not assignable to type 'null'. (js)
					tooltipFeature = feature;
					tooltipEvent = event;
				}}

src/routes/_components/Tooltip.html.svelte:63:6
Error: Cannot find name 'tooltipFeatures'. Did you mean 'tooltipFeature'? (js)
				onmouseout={() => {
					tooltipFeatures = null;
					tooltipEvent = null;
```