### PR TITLE
Fix Typescript error for getBoundingClientRect

### DIFF
--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -60,9 +60,12 @@
 	function onresize() {
 		if (container) {
 			const { top } = container.getBoundingClientRect();
-			positions = [].map.call(anchors, anchor => {
-				return anchor.getBoundingClientRect().top - top;
-			});
+			positions = [].map.call(
+				anchors,
+				/** @param {HTMLAnchorElement} anchor */ anchor => {
+					return anchor.getBoundingClientRect().top - top;
+				}
+			);
 		}
 	}
 

--- a/src/routes/guide/+page.svelte
+++ b/src/routes/guide/+page.svelte
@@ -24,9 +24,12 @@
 	function onresize() {
 		if (container) {
 			const { top } = container.getBoundingClientRect();
-			positions = [].map.call(anchors, /** @param {HTMLAnchorElement} anchor */ anchor => {
-				return anchor.getBoundingClientRect().top - top;
-			});
+			positions = [].map.call(
+				anchors,
+				/** @param {HTMLAnchorElement} anchor */ anchor => {
+					return anchor.getBoundingClientRect().top - top;
+				}
+			);
 		}
 	}
 


### PR DESCRIPTION
A tiny fix for a TypeScript error:

Error was

src/routes/guide/+page.svelte:29:19
Error: Property 'getBoundingClientRect' does not exist on type 'never'. (js) positions = [].map.call(anchors, anchor => {
	return anchor.getBoundingClientRect().top - top;
});

I also tried typing `anchors` but it wouldn't pick it up and complain about the `[]` default, so this is probably the easiest fix.
