### PR TITLE
Fix some type errors in getSections

### DIFF
--- a/src/_modules/getSections.js
+++ b/src/_modules/getSections.js
@@ -78,6 +78,7 @@ export default function (returnHtml = true) {
 			let group = null;
 			let uid = 1;
 
+			/** @type {import('marked').RendererObject} */
 			const renderer = {
 				heading(token) {
 					// In marked v16, the heading renderer receives a single token object
@@ -106,7 +107,7 @@ export default function (returnHtml = true) {
 								if (t.type === 'codespan') {
 									return `<code>${t.text}</code>`;
 								}
-								return t.text || '';
+								return 'text' in t ? t.text : '';
 							})
 							.join('');
 					} else {
@@ -203,7 +204,7 @@ export default function (returnHtml = true) {
 
 			marked.use({ renderer });
 
-			let html = marked.marked(content);
+			let html = marked.marked(content, { async: false });
 
 			const hashes = {};
 


### PR DESCRIPTION
Adding a general type from marked.js for the custom renderer and setting `async` to false fixes a few errors in `getSections.js`.

Errors were
```
layercake/src/_modules/getSections.js:204:17
Error: Type '{ heading(token: any): string; code(token: any): string; blockquote(): boolean; html(): boolean; hr(): boolean; list(): boolean; listitem(): boolean; paragraph(): boolean; table(): boolean; tablerow(): boolean; tablecell(): boolean; }' is not assignable to type 'RendererObject<string, string>'.
  The types returned by 'blockquote(...)' are incompatible between these types.
    Type 'boolean' is not assignable to type 'string | false'. 

--

layercake/src/_modules/getSections.js:246:33
Error: Argument of type 'string | Promise<string>' is not assignable to parameter of type 'string'.
  Type 'Promise<string>' is not assignable to type 'string'. 

			while ((match = pattern.exec(html))) {
--

layercake/src/_modules/getSections.js:278:33
Error: Argument of type 'string | Promise<string>' is not assignable to parameter of type 'string'.
  Type 'Promise<string>' is not assignable to type 'string'. 
			// Nicer formatting for function calls and args
			while ((match = pattern.exec(html))) {
--

layercake/src/_modules/getSections.js:287:17
Error: Property 'replace' does not exist on type 'string | Promise<string>'.
  Property 'replace' does not exist on type 'Promise<string>'. 
				});
				html = html.replace(match[2], formatted);
--

layercake/src/_modules/getSections.js:291:38
Error: Property 'replace' does not exist on type 'string | Promise<string>'.
  Property 'replace' does not exist on type 'Promise<string>'. 
			return {
				html: returnHtml === true ? html.replace(/@@(\d+)/g, (m, id) => hashes[id] || m) : null,
```