### PR TITLE
Add type to attribute functions in Scatter.webgl

### DIFF
--- a/src/_components/Scatter.webgl.svelte
+++ b/src/_components/Scatter.webgl.svelte
@@ -117,7 +117,12 @@
 					gl_PointSize = r;
 					gl_Position = vec4(normalizeCoords(position), 0.0, 1.0);
 				}`,
+
 				attributes: {
+					/**
+					 * @param {any} context
+					 * @param {{ points: Array<any>, pointWidth?: number }} props
+					 */
 					// There will be a position value for each point
 					// we pass in
 					position: (context, props) => {


### PR DESCRIPTION
Not really sure what's going on here, but this seems to fix the following errors:

```
layercake/src/_components/Scatter.webgl.svelte:124:20
Error: Property 'points' does not exist on type '{}'. (js)
					position: (context, props) => {
						return props.points.map(point => {
							return [$xGet(point), $yGet(point)];

layercake/src/_components/Scatter.webgl.svelte:131:20
Error: Property 'points' does not exist on type '{}'. (js)
						// If using an r-scale, set width here
						return props.points.map(p => props.pointWidth);
					},

layercake/src/_components/Scatter.webgl.svelte:131:42
Error: Property 'pointWidth' does not exist on type '{}'. (js)
						// If using an r-scale, set width here
						return props.points.map(p => props.pointWidth);
					},

layercake/src/_components/Scatter.webgl.svelte:135:20
Error: Property 'points' does not exist on type '{}'. (js)
						// If using an r-scale, set that here
						return props.points.map(p => 0);
					}

layercake/src/_components/Scatter.webgl.svelte:151:19
Error: Property 'points' does not exist on type '{}'. (js)
					// set the count based on the number of points we have
					return props.points.length;
```