### PR TITLE
Workaround Typescript error in Voronoi component

### DIFF
--- a/src/_components/Voronoi.svelte
+++ b/src/_components/Voronoi.svelte
@@ -26,7 +26,7 @@
 	let points = $derived(
 		$data.map(d => {
 			const point = [$xGet(d), $yGet(d)];
-			point.data = d;
+			point["data"] = d;
 			return point;
 		})
 	);


### PR DESCRIPTION
Error was
```
/layercake/src/_components/Voronoi.svelte:29:10
Error: Property 'data' does not exist on type 'any[]'. (js)
			const point = [$xGet(d), $yGet(d)];
			point.data = d;
			return point;
```