### PR TITLE
Workaround Map.svg type errors

### DIFF
--- a/src/_components/Map.svg.svelte
+++ b/src/_components/Map.svg.svelte
@@ -44,6 +44,7 @@
 
 	function handleMousemove(feature) {
 		return function handleMousemoveFn(e) {
+			// @ts-ignore
 			raise(this);
 			// When the element gets raised, it flashes 0,0 for a second so skip that
 			if (e.layerX !== 0 && e.layerY !== 0) {
@@ -53,9 +54,9 @@
 	}
 </script>
 
-<g class="map-group" {onmouseout} onblur={onmouseout} role="tooltip">
+<!-- svelte-ignore a11y_mouse_events_have_key_events -->
+<g class="map-group" {onmouseout} role="tooltip">
 	{#each features || $data.features as feature}
-		<!-- svelte-ignore a11y_mouse_events_have_key_events -->
 		<path
 			class="feature-path"
 			fill={fill || $zGet(feature.properties)}


### PR DESCRIPTION
The errors were

```
layercake/src/_components/Map.svg.svelte:47:10
Error: 'this' implicitly has type 'any' because it does not have a type annotation. (js)
            return function handleMousemoveFn(e) {
                        raise(this);
                        // When the element gets raised, it flashes 0,0 for a second so skip that

layercake/src/_components/Map.svg.svelte:56:35
Error: Type '(e: MouseEvent) => void' is not assignable to type 'FocusEventHandler<SVGGElement>'.
  Types of parameters 'e' and 'event' are incompatible.
    Type 'FocusEvent & { currentTarget: EventTarget & SVGGElement; }' is missing the following properties from type 'MouseEvent': altKey, button, buttons, clientX, and 18 more. (js)

<g class="map-group" {onmouseout} onblur={onmouseout} role="tooltip">
        {#each features || $data.features as feature}

```

This just ignores the `this` error and removes the `onblur` handler. I t think it might not be needed. In the example, it seems it's only possible to focus the map in Chrome (not in Firefox) with tabbing to it, but not individual states. So if you blur the map there won't be any highlighted state tooltips.