### PR TITLE
Fix error with too many args and simplify arrowUtils

### DIFF
--- a/src/_modules/arrowUtils.js
+++ b/src/_modules/arrowUtils.js
@@ -58,8 +58,8 @@ export function swoopyArrow() {
 	}
 
 	function render(data) {
-		data = data.map((d, i) => {
-			return [xValue.call(data, d, i), yValue.call(data, d, i)];
+		data = data.map((d) => {
+			return [xValue(d), yValue(d)];
 		});
 
 		// get the chord length ("height" {h}) between points


### PR DESCRIPTION
Error was

```
/layercake/src/_modules/arrowUtils.js:62:33
Error: Expected 1-2 arguments, but got 3. 
            data = data.map((d, i) => {
                        return [xValue.call(data, d, i), yValue.call(data, d, i)];
                });

/layercake/src/_modules/arrowUtils.js:62:58
Error: Expected 1-2 arguments, but got 3. 
            data = data.map((d, i) => {
                        return [xValue.call(data, d, i), yValue.call(data, d, i)];
                });
```

I simplified the expression to directly call `xValue`/`yValue`.