### PR TITLE
Remove tick label conversion

### DIFF
--- a/src/routes/_examples/Histogram.svelte
+++ b/src/routes/_examples/Histogram.svelte
@@ -53,7 +53,7 @@
 		data={binnedData}
 	>
 		<Svg>
-			<AxisX gridlines={false} baseline ticks={slimThresholds} format={d => +f(d)} />
+			<AxisX gridlines={false} baseline ticks={slimThresholds} format={d => String(+f(d))} />
 			<AxisY gridlines={false} ticks={3} />
 			<Column fill="#fff" stroke="#000" strokeWidth={1} />
 		</Svg>

--- a/src/routes/_examples/Histogram.svelte
+++ b/src/routes/_examples/Histogram.svelte
@@ -53,7 +53,7 @@
 		data={binnedData}
 	>
 		<Svg>
-			<AxisX gridlines={false} baseline ticks={slimThresholds} format={d => f(d)} />
+			<AxisX gridlines={false} baseline ticks={slimThresholds} format={d => +f(d)} />
 			<AxisY gridlines={false} ticks={3} />
 			<Column fill="#fff" stroke="#000" strokeWidth={1} />
 		</Svg>

--- a/src/routes/_examples/Histogram.svelte
+++ b/src/routes/_examples/Histogram.svelte
@@ -53,7 +53,7 @@
 		data={binnedData}
 	>
 		<Svg>
-			<AxisX gridlines={false} baseline ticks={slimThresholds} format={d => +f(d)} />
+			<AxisX gridlines={false} baseline ticks={slimThresholds} format={d => f(d)} />
 			<AxisY gridlines={false} ticks={3} />
 			<Column fill="#fff" stroke="#000" strokeWidth={1} />
 		</Svg>

--- a/src/routes/_examples_ssr/Histogram.svelte
+++ b/src/routes/_examples_ssr/Histogram.svelte
@@ -49,7 +49,7 @@
 		data={hist(data)}
 	>
 		<Html>
-			<AxisX gridlines={false} baseline ticks={slimSteps} format={d => +f(d)} />
+			<AxisX gridlines={false} baseline ticks={slimSteps} format={d => String(+f(d))} />
 			<AxisY gridlines={false} ticks={3} />
 		</Html>
 		<ScaledSvg>

--- a/src/routes/_examples_ssr/Histogram.svelte
+++ b/src/routes/_examples_ssr/Histogram.svelte
@@ -49,7 +49,7 @@
 		data={hist(data)}
 	>
 		<Html>
-			<AxisX gridlines={false} baseline ticks={slimSteps} format={d => f(d)} />
+			<AxisX gridlines={false} baseline ticks={slimSteps} format={d => +f(d)} />
 			<AxisY gridlines={false} ticks={3} />
 		</Html>
 		<ScaledSvg>

--- a/src/routes/_examples_ssr/Histogram.svelte
+++ b/src/routes/_examples_ssr/Histogram.svelte
@@ -49,7 +49,7 @@
 		data={hist(data)}
 	>
 		<Html>
-			<AxisX gridlines={false} baseline ticks={slimSteps} format={d => +f(d)} />
+			<AxisX gridlines={false} baseline ticks={slimSteps} format={d => f(d)} />
 			<AxisY gridlines={false} ticks={3} />
 		</Html>
 		<ScaledSvg>


### PR DESCRIPTION
Error was
```shell
`/layercake/src/routes/_examples/Histogram.svelte:56:61
Error: Type '(d: any) => number' is not assignable to type '(d: any) => string'.
  Type 'number' is not assignable to type 'string'. (js)
		<Svg>
			<AxisX gridlines={false} baseline ticks={slimThresholds} format={d => +f(d)} />

/layercake/src/routes/_examples_ssr/Histogram.svelte:52:56
Error: Type '(d: any) => number' is not assignable to type '(d: any) => string'.
  Type 'number' is not assignable to type 'string'. (js)
		<Html>
			<AxisX gridlines={false} baseline ticks={slimSteps} format={d => +f(d)} />


```

This PR removes the conversion to number.