### PR TITLE
Svelte 5 peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 				"npm": ">=11.0.0"
 			},
 			"peerDependencies": {
-				"svelte": "3 - 5 || >=5.0.0-next.120",
+				"svelte": "5",
 				"typescript": "^5.0.2"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"npm": ">=11.0.0"
 	},
 	"peerDependencies": {
-		"svelte": "3 - 5 || >=5.0.0-next.120",
+		"svelte": "5",
 		"typescript": "^5.0.2"
 	},
 	"svelte": "./dist/index.js"


### PR DESCRIPTION
Closes https://github.com/mhkeller/layercake/issues/329

Users still using Svelte 3 or 4 can use version `v8.4.4`