### PR TITLE
Fix type issues and silence warning in Voronoi component

### DIFF
--- a/src/_components/Voronoi.svelte
+++ b/src/_components/Voronoi.svelte
@@ -9,6 +9,8 @@
 
 	const { data, xGet, yGet, width, height } = getContext('LayerCake');
 
+	/** @typedef {[number, number] & { data?: any }} Point */
+
 	/**
 	 * @typedef {Object} Props
 	 * @property {string|undefined} [stroke] - An optional stroke color, which is likely only useful for testing to make sure the shapes drew correctly.
@@ -18,31 +20,37 @@
 	/** @type {Props} */
 	let { stroke, onmouseover = () => {} } = $props();
 
+	/**
+	 * @param {MouseEvent} e
+	 * @param {Point} point
+	 */
 	function log(e, point) {
 		console.log(point, point.data);
 		onmouseover(e, point);
 	}
 
+	/** @type {Point[]} */
 	let points = $derived(
 		$data.map(d => {
+			/** @type {Point} */
 			const point = [$xGet(d), $yGet(d)];
-			point["data"] = d;
+			point.data = d;
 			return point;
 		})
 	);
 
-	let uniquePoints = $derived(uniques(points, d => d.join(), false));
+	let uniquePoints = $derived(uniques(points, d => d.join(), false) ?? []);
 
-	let voronoi = $derived(Delaunay.from(uniquePoints).voronoi([0, 0, $width, $height]));
+	let voronoi = $derived(Delaunay.from(uniquePoints ?? []).voronoi([0, 0, $width, $height]));
 </script>
 
 {#each uniquePoints as point, i}
+	<!-- svelte-ignore a11y_mouse_events_have_key_events -->
 	<path
 		style="stroke: {stroke}"
 		class="voronoi-cell"
 		d={voronoi.renderCell(i)}
 		onmouseover={e => log(e, point)}
-		onfocus={e => log(e, point)}
 		role="tooltip"
 	></path>
 {/each}


### PR DESCRIPTION
Some typing improvements for the Voronoi component.

Errors were:
```
/layercake/src/_components/Voronoi.svelte:21:15
Error: Parameter 'e' implicitly has an 'any' type. (js)

	function log(e, point) {
		console.log(point, point.data);
--
/layercake/src/_components/Voronoi.svelte:21:18
Error: Parameter 'point' implicitly has an 'any' type. (js)

	function log(e, point) {
		console.log(point, point.data);
--
/layercake/src/_components/Voronoi.svelte:29:10
Error: Element implicitly has an 'any' type because index expression is not of type 'number'. (js)
			const point = [$xGet(d), $yGet(d)];
			point["data"] = d;
			return point;
--
/layercake/src/_components/Voronoi.svelte:36:39
Error: Argument of type 'any[] | null' is not assignable to parameter of type 'ArrayLike<Point> | Iterable<Point>'.
  Type 'null' is not assignable to type 'ArrayLike<Point> | Iterable<Point>'. (js)

	let voronoi = $derived(Delaunay.from(uniquePoints).voronoi([0, 0, $width, $height]));
--
/layercake/src/_components/Voronoi.svelte:39:8
Error: Argument of type 'any[] | null' is not assignable to parameter of type 'ArrayLike<unknown> | Iterable<unknown>'.
  Type 'null' is not assignable to type 'ArrayLike<unknown> | Iterable<unknown>'. (js)

{#each uniquePoints as point, i}
```

There is no real focus support so it's better to silence the a11y warning instead of having a fake focus handler I think.